### PR TITLE
travis: Bump macOS and Xcode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: osx
+osx_image: xcode11.3
 language: csharp
 mono: beta
 


### PR DESCRIPTION
The default version of macOS in Travis isn't new enough to support dark theme, so our app builds are stuck on the light theme. This bumps the version.