### PR TITLE
Introduces IColorConverter into the CodeRendererService and ViewRendererService

### DIFF
--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
@@ -32,97 +32,109 @@ using AppKit;
 
 namespace FigmaSharp.NativeControls.Cocoa
 {
-	class ColorConverter : IColorConverter
+	public class ColorConverter : IColorConverter
 	{
 		public ColorConverter()
 		{
 		}
 
-		const string LIGHT_THEME_NAME    = "Light";
-		const string LIGHT_HC_THEME_NAME = "Light HC";
-		const string DARK_THEME_NAME     = "Dark;";
-		const string DARK_HC_THEME_NAME  = "Dark HC";
+		static string LightThemeName    = "Light";
+		static string LightHcThemeName = $"{LightThemeName} HC";
+		static string DarkThemeName     = "Dark";
+		static string DarkHcThemeName  = $"{DarkThemeName} HC";
 
-		public object FromStyle (object colorStyleName)
+		public object FromStyleToColor (string colorStyleName)
 		{
 			if (colorStyleName is string value)
             {
-				foreach (string themeName in new[] { LIGHT_THEME_NAME, LIGHT_HC_THEME_NAME, DARK_THEME_NAME, DARK_HC_THEME_NAME })
-					value = value.Replace(string.Format("{0}/", themeName), string.Empty);
-
-				return ThemeColors.FirstOrDefault(c => c.styleName == value).themeColor;
+				var index = value.IndexOf("/");
+				if (index > -1) {
+					value = value.Substring(index + 1);
+				}
+				var color = ThemeColors.FirstOrDefault(c => c.styleName == value).color;
+				return color;
 			}
-			Console.WriteLine($"{nameof (ColorConverter)}.{nameof (FromStyle)} (): Cannot convert {colorStyleName?.GetType ()} into {typeof (string).FullName}");
+			Console.WriteLine($"{nameof (ColorConverter)}.{nameof (FromStyleToColor)} (): Cannot convert {colorStyleName?.GetType ()} into {typeof (string).FullName}");
 			return null;
 		}
 
-		public object FromColor (object color)
+		public string FromColorToStyle (object color)
 		{
-			if (color is NSColor nsColor)
-				return ThemeColors.FirstOrDefault(c => c.themeColor == nsColor).styleName;
-
-			Console.WriteLine($"{nameof(ColorConverter)}.{nameof(FromColor)} (): Cannot convert {color?.GetType()} into {typeof(NSColor).FullName}");
-			return null;
+			return ThemeColors.FirstOrDefault(c => c.color == color).styleName;
 		}
 
-        public object ToStringColor (object color)
+		public string FromStyleToStringColor (string style)
+		{
+			return string.Format ("{0}.{1}", typeof (NSColor).FullName, ThemeColors.FirstOrDefault(c => c.styleName == style).nsColorName);
+		}
+
+        public object FromStringColorToStyle (object color)
         {
-
-
+			if (color is string colorStr)
+			{
+				var index = colorStr.LastIndexOf(".");
+				if (index > 0)
+				{
+					colorStr = colorStr.Substring(index + 1);
+					var styleName = ThemeColors.FirstOrDefault(c => c.nsColorName == colorStr).styleName;
+					return styleName;
+				}
+			}
+			return null;
         }
 
-        static IReadOnlyList<(string styleName, NSColor themeColor)> ThemeColors = new List<(string styleName, NSColor themeColor)>
+        static IReadOnlyList<(string styleName, NSColor color, string nsColorName)> ThemeColors = new List<(string styleName, NSColor color, string nsColorName)>
 		{
 			// System color palette
-			("System/Red", NSColor.SystemRedColor),
-			("System/Green", NSColor.SystemGreenColor),
-			("System/Blue", NSColor.SystemBlueColor),
-			("System/Orange", NSColor.SystemOrangeColor),
-			("System/Yellow", NSColor.SystemYellowColor),
-			("System/Brown", NSColor.SystemBrownColor),
-			("System/Pink", NSColor.SystemPinkColor),
-			("System/Purple", NSColor.SystemPurpleColor),
-			("System/Teal", NSColor.SystemTealColor),
-			("System/Indigo", NSColor.SystemIndigoColor),
-			("System/Gray", NSColor.SystemGrayColor),
+			("System/Light/Red", NSColor.SystemRedColor, nameof (NSColor.SystemRedColor)),
+			("System/Light/Green", NSColor.SystemGreenColor, nameof (NSColor.SystemGreenColor)),
+			("System/Light/Blue", NSColor.SystemBlueColor, nameof ( NSColor.SystemBlueColor)),
+			("System/Light/Orange", NSColor.SystemOrangeColor, nameof (NSColor.SystemOrangeColor)),
+			("System/Light/Yellow", NSColor.SystemYellowColor, nameof (NSColor.SystemYellowColor)),
+			("System/Light/Brown",NSColor.SystemBrownColor, nameof ( NSColor.SystemBrownColor)),
+			("System/Light/Pink", NSColor.SystemPinkColor, nameof (NSColor.SystemPinkColor)),
+			("System/Light/Purple", NSColor.SystemPurpleColor, nameof (NSColor.SystemPurpleColor)),
+			("System/Teal", NSColor.SystemTealColor, nameof (NSColor.SystemTealColor)),
+			//("System/Indigo", NSColor.SystemIndigoColor), //breaks in mojave
+			("System/Gray", NSColor.SystemGrayColor, nameof (NSColor.SystemGrayColor)),
 
 			// Text
-			("Text/Label", NSColor.LabelColor),
-			("Text/Label Secondary", NSColor.SecondaryLabelColor),
-			("Text/Label Tertiary", NSColor.TertiaryLabelColor),
-			("Text/Label Quaternary", NSColor.QuaternaryLabelColor),
-			("Text/Link", NSColor.LinkColor),
-			("Text/Placeholder", NSColor.PlaceholderTextColor),
-			("Text/Window Frame", NSColor.WindowFrameText),
-			("Text/Menu Item Selected", NSColor.SelectedMenuItemText),
-			("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText),
-			("Text/Header", NSColor.HeaderText),
-			("Text/Text", NSColor.Text),
-			("Text/Selected", NSColor.SelectedText),
-			("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor),
-			("Text/Control", NSColor.ControlText),
-			("Text/Control Selected", NSColor.SelectedControlText),
-			("Text/Control Disabled", NSColor.DisabledControlText),
+			("Text/Label", NSColor.LabelColor, nameof ( NSColor.LabelColor)),
+			("Text/Label Secondary", NSColor.SecondaryLabelColor, nameof (NSColor.SecondaryLabelColor)),
+			("Text/Label Tertiary", NSColor.TertiaryLabelColor, nameof ( NSColor.TertiaryLabelColor)),
+			("Text/Label Quaternary", NSColor.QuaternaryLabelColor, nameof ( NSColor.QuaternaryLabelColor)),
+			("Text/Link", NSColor.LinkColor, nameof (NSColor.LinkColor)),
+			("Text/Placeholder", NSColor.PlaceholderTextColor, nameof (NSColor.PlaceholderTextColor)),
+			("Text/Window Frame", NSColor.WindowFrameText, nameof (NSColor.WindowFrameText)),
+			("Text/Menu Item Selected", NSColor.SelectedMenuItemText, nameof (NSColor.SelectedMenuItemText)),
+			("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText, nameof (NSColor.AlternateSelectedControlText)),
+			("Text/Header", NSColor.HeaderText, nameof (NSColor.HeaderText)),
+			("Text/Text", NSColor.Text, nameof (NSColor.Text)),
+			("Text/Selected", NSColor.SelectedText, nameof (NSColor.SelectedText)),
+			("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor, nameof (NSColor.UnemphasizedSelectedTextColor)),
+			("Text/Control", NSColor.ControlText, nameof (NSColor.ControlText)),
+			("Text/Control Selected", NSColor.SelectedControlText, nameof (NSColor.SelectedControlText)),
+			("Text/Control Disabled", NSColor.DisabledControlText, nameof (NSColor.DisabledControlText)),
 
 			// Chrome
-			("Chrome/Separator", NSColor.SeparatorColor),
-			("Chrome/Grid", NSColor.Grid),
-			("Chrome/Text BG", NSColor.TextBackground),
-			("Chrome/Text Selected BG", NSColor.SelectedTextBackground),
-			("Chrome/Text Selected Unemphasized BG", NSColor.UnemphasizedSelectedTextBackgroundColor),
-			("Chrome/Window BG", NSColor.WindowBackground),
-			("Chrome/Under Page BG", NSColor.UnderPageBackgroundColor),
-			("Chrome/Control BG", NSColor.ControlBackground),
-			("Chrome/Content Selected BG", NSColor.SelectedContentBackgroundColor),
-			("Chrome/Content Selected Unemphasized BG", NSColor.UnemphasizedSelectedContentBackgroundColor),
-			("Chrome/Content Alternating BG", NSColor.AlternatingContentBackgroundColors[1]),
-			("Chrome/Control", NSColor.Control),
-			("Chrome/Control Selected", NSColor.SelectedControl),
-			("Chrome/Control Accent", NSColor.ControlAccentColor),
+			//("Chrome/Separator", NSColor.SeparatorColor),
+			//("Chrome/Grid", NSColor.Grid),
+			//("Chrome/Text BG", NSColor.TextBackground),
+			//("Chrome/Text Selected BG", NSColor.SelectedTextBackground),
+			//("Chrome/Text Selected Unemphasized BG", NSColor.UnemphasizedSelectedTextBackgroundColor),
+			//("Chrome/Window BG", NSColor.WindowBackground),
+			//("Chrome/Under Page BG", NSColor.UnderPageBackgroundColor),
+			//("Chrome/Control BG", NSColor.ControlBackground),
+			//("Chrome/Content Selected BG", NSColor.SelectedContentBackgroundColor),
+			//("Chrome/Content Selected Unemphasized BG", NSColor.UnemphasizedSelectedContentBackgroundColor),
+			//("Chrome/Content Alternating BG", NSColor.AlternatingContentBackgroundColors[1]),
+			//("Chrome/Control", NSColor.Control),
+			//("Chrome/Control Selected", NSColor.SelectedControl),
+			//("Chrome/Control Accent", NSColor.ControlAccentColor),
 
-			// Misc
-			("Misc/Find Highlight", NSColor.FindHighlightColor),
-			("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator),
+			//// Misc
+			//("Misc/Find Highlight", NSColor.FindHighlightColor),
+			//("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator),
 		};
 	}
 

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
@@ -24,6 +24,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -31,7 +32,7 @@ using AppKit;
 
 namespace FigmaSharp.NativeControls.Cocoa
 {
-	public class ColorConverter
+	class ColorConverter : IColorConverter
 	{
 		public ColorConverter()
 		{
@@ -42,15 +43,35 @@ namespace FigmaSharp.NativeControls.Cocoa
 		const string DARK_THEME_NAME     = "Dark;";
 		const string DARK_HC_THEME_NAME  = "Dark HC";
 
-		public NSColor GetThemeColor(string colorStyleName)
+		public object FromStyle (object colorStyleName)
 		{
-			foreach (string themeName in new[] { LIGHT_THEME_NAME, LIGHT_HC_THEME_NAME, DARK_THEME_NAME, DARK_HC_THEME_NAME })
-				colorStyleName = colorStyleName.Replace(string.Format("{0}/", themeName), string.Empty);
+			if (colorStyleName is string value)
+            {
+				foreach (string themeName in new[] { LIGHT_THEME_NAME, LIGHT_HC_THEME_NAME, DARK_THEME_NAME, DARK_HC_THEME_NAME })
+					value = value.Replace(string.Format("{0}/", themeName), string.Empty);
 
-			return ThemeColors.FirstOrDefault(c => c.styleName == colorStyleName).themeColor;
+				return ThemeColors.FirstOrDefault(c => c.styleName == value).themeColor;
+			}
+			Console.WriteLine($"{nameof (ColorConverter)}.{nameof (FromStyle)} (): Cannot convert {colorStyleName?.GetType ()} into {typeof (string).FullName}");
+			return null;
 		}
 
-		public static IReadOnlyList<(string styleName, NSColor themeColor)> ThemeColors = new List<(string styleName, NSColor themeColor)>
+		public object FromColor (object color)
+		{
+			if (color is NSColor nsColor)
+				return ThemeColors.FirstOrDefault(c => c.themeColor == nsColor).styleName;
+
+			Console.WriteLine($"{nameof(ColorConverter)}.{nameof(FromColor)} (): Cannot convert {color?.GetType()} into {typeof(NSColor).FullName}");
+			return null;
+		}
+
+        public object ToStringColor (object color)
+        {
+
+
+        }
+
+        static IReadOnlyList<(string styleName, NSColor themeColor)> ThemeColors = new List<(string styleName, NSColor themeColor)>
 		{
 			// System color palette
 			("System/Red", NSColor.SystemRedColor),
@@ -104,4 +125,5 @@ namespace FigmaSharp.NativeControls.Cocoa
 			("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator),
 		};
 	}
+
 }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
@@ -24,52 +24,48 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using AppKit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using AppKit;
 
 namespace FigmaSharp.NativeControls.Cocoa
 {
 	public class ColorConverter : IColorConverter
 	{
-		public ColorConverter()
-		{
-		}
-
-		static string LightThemeName    = "Light";
+		static string LightThemeName = "Light";
 		static string LightHcThemeName = $"{LightThemeName} HC";
-		static string DarkThemeName     = "Dark";
-		static string DarkHcThemeName  = $"{DarkThemeName} HC";
+		static string DarkThemeName = "Dark";
+		static string DarkHcThemeName = $"{DarkThemeName} HC";
 
-		public object FromStyleToColor (string colorStyleName)
+		public object FromStyleToColor(string colorStyleName)
 		{
 			if (colorStyleName is string value)
-            {
+			{
 				var index = value.IndexOf("/");
-				if (index > -1) {
+				if (index > -1)
+				{
 					value = value.Substring(index + 1);
 				}
 				var color = ThemeColors.FirstOrDefault(c => c.styleName == value).color;
 				return color;
 			}
-			Console.WriteLine($"{nameof (ColorConverter)}.{nameof (FromStyleToColor)} (): Cannot convert {colorStyleName?.GetType ()} into {typeof (string).FullName}");
+			Console.WriteLine($"{nameof(ColorConverter)}.{nameof(FromStyleToColor)} (): Cannot convert {colorStyleName?.GetType()} into {typeof(string).FullName}");
 			return null;
 		}
 
-		public string FromColorToStyle (object color)
+		public string FromColorToStyle(object color)
 		{
 			return ThemeColors.FirstOrDefault(c => c.color == color).styleName;
 		}
 
-		public string FromStyleToStringColor (string style)
+		public string FromStyleToStringColor(string style)
 		{
-			return string.Format ("{0}.{1}", typeof (NSColor).FullName, ThemeColors.FirstOrDefault(c => c.styleName == style).nsColorName);
+			return string.Format("{0}.{1}", typeof(NSColor).FullName, ThemeColors.FirstOrDefault(c => c.styleName == style).nsColorName);
 		}
 
-        public object FromStringColorToStyle (object color)
-        {
+		public object FromStringColorToStyle(object color)
+		{
 			if (color is string colorStr)
 			{
 				var index = colorStr.LastIndexOf(".");
@@ -81,40 +77,40 @@ namespace FigmaSharp.NativeControls.Cocoa
 				}
 			}
 			return null;
-        }
+		}
 
-        static IReadOnlyList<(string styleName, NSColor color, string nsColorName)> ThemeColors = new List<(string styleName, NSColor color, string nsColorName)>
+		static IReadOnlyList<(string styleName, NSColor color, string nsColorName)> ThemeColors = new List<(string styleName, NSColor color, string nsColorName)>
 		{
 			// System color palette
-			("System/Light/Red", NSColor.SystemRedColor, nameof (NSColor.SystemRedColor)),
-			("System/Light/Green", NSColor.SystemGreenColor, nameof (NSColor.SystemGreenColor)),
-			("System/Light/Blue", NSColor.SystemBlueColor, nameof ( NSColor.SystemBlueColor)),
-			("System/Light/Orange", NSColor.SystemOrangeColor, nameof (NSColor.SystemOrangeColor)),
-			("System/Light/Yellow", NSColor.SystemYellowColor, nameof (NSColor.SystemYellowColor)),
-			("System/Light/Brown",NSColor.SystemBrownColor, nameof ( NSColor.SystemBrownColor)),
-			("System/Light/Pink", NSColor.SystemPinkColor, nameof (NSColor.SystemPinkColor)),
-			("System/Light/Purple", NSColor.SystemPurpleColor, nameof (NSColor.SystemPurpleColor)),
-			("System/Teal", NSColor.SystemTealColor, nameof (NSColor.SystemTealColor)),
-			//("System/Indigo", NSColor.SystemIndigoColor), //breaks in mojave
-			("System/Gray", NSColor.SystemGrayColor, nameof (NSColor.SystemGrayColor)),
+			//("System/Light/Red", NSColor.SystemRedColor, nameof (NSColor.SystemRedColor)),
+            //("System/Light/Green", NSColor.SystemGreenColor, nameof (NSColor.SystemGreenColor)),
+            //("System/Light/Blue", NSColor.SystemBlueColor, nameof ( NSColor.SystemBlueColor)),
+            //("System/Light/Orange", NSColor.SystemOrangeColor, nameof (NSColor.SystemOrangeColor)),
+            //("System/Light/Yellow", NSColor.SystemYellowColor, nameof (NSColor.SystemYellowColor)),
+            //("System/Light/Brown",NSColor.SystemBrownColor, nameof ( NSColor.SystemBrownColor)),
+            //("System/Light/Pink", NSColor.SystemPinkColor, nameof (NSColor.SystemPinkColor)),
+            //("System/Light/Purple", NSColor.SystemPurpleColor, nameof (NSColor.SystemPurpleColor)),
+            //("System/Teal", NSColor.SystemTealColor, nameof (NSColor.SystemTealColor)),
+			////("System/Indigo", NSColor.SystemIndigoColor), //breaks in mojave
+			//("System/Gray", NSColor.SystemGrayColor, nameof (NSColor.SystemGrayColor)),
 
-			// Text
-			("Text/Label", NSColor.LabelColor, nameof ( NSColor.LabelColor)),
-			("Text/Label Secondary", NSColor.SecondaryLabelColor, nameof (NSColor.SecondaryLabelColor)),
-			("Text/Label Tertiary", NSColor.TertiaryLabelColor, nameof ( NSColor.TertiaryLabelColor)),
-			("Text/Label Quaternary", NSColor.QuaternaryLabelColor, nameof ( NSColor.QuaternaryLabelColor)),
-			("Text/Link", NSColor.LinkColor, nameof (NSColor.LinkColor)),
-			("Text/Placeholder", NSColor.PlaceholderTextColor, nameof (NSColor.PlaceholderTextColor)),
-			("Text/Window Frame", NSColor.WindowFrameText, nameof (NSColor.WindowFrameText)),
-			("Text/Menu Item Selected", NSColor.SelectedMenuItemText, nameof (NSColor.SelectedMenuItemText)),
-			("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText, nameof (NSColor.AlternateSelectedControlText)),
-			("Text/Header", NSColor.HeaderText, nameof (NSColor.HeaderText)),
-			("Text/Text", NSColor.Text, nameof (NSColor.Text)),
-			("Text/Selected", NSColor.SelectedText, nameof (NSColor.SelectedText)),
-			("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor, nameof (NSColor.UnemphasizedSelectedTextColor)),
-			("Text/Control", NSColor.ControlText, nameof (NSColor.ControlText)),
-			("Text/Control Selected", NSColor.SelectedControlText, nameof (NSColor.SelectedControlText)),
-			("Text/Control Disabled", NSColor.DisabledControlText, nameof (NSColor.DisabledControlText)),
+			//// Text
+			//("Text/Label", NSColor.LabelColor, nameof ( NSColor.LabelColor)),
+			//("Text/Label Secondary", NSColor.SecondaryLabelColor, nameof (NSColor.SecondaryLabelColor)),
+			//("Text/Label Tertiary", NSColor.TertiaryLabelColor, nameof ( NSColor.TertiaryLabelColor)),
+			//("Text/Label Quaternary", NSColor.QuaternaryLabelColor, nameof ( NSColor.QuaternaryLabelColor)),
+			//("Text/Link", NSColor.LinkColor, nameof (NSColor.LinkColor)),
+			//("Text/Placeholder", NSColor.PlaceholderTextColor, nameof (NSColor.PlaceholderTextColor)),
+			//("Text/Window Frame", NSColor.WindowFrameText, nameof (NSColor.WindowFrameText)),
+			//("Text/Menu Item Selected", NSColor.SelectedMenuItemText, nameof (NSColor.SelectedMenuItemText)),
+			//("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText, nameof (NSColor.AlternateSelectedControlText)),
+			//("Text/Header", NSColor.HeaderText, nameof (NSColor.HeaderText)),
+			//("Text/Text", NSColor.Text, nameof (NSColor.Text)),
+			//("Text/Selected", NSColor.SelectedText, nameof (NSColor.SelectedText)),
+			//("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor, nameof (NSColor.UnemphasizedSelectedTextColor)),
+			//("Text/Control", NSColor.ControlText, nameof (NSColor.ControlText)),
+			//("Text/Control Selected", NSColor.SelectedControlText, nameof (NSColor.SelectedControlText)),
+			//("Text/Control Disabled", NSColor.DisabledControlText, nameof (NSColor.DisabledControlText)),
 
 			// Chrome
 			//("Chrome/Separator", NSColor.SeparatorColor),
@@ -137,5 +133,4 @@ namespace FigmaSharp.NativeControls.Cocoa
 			//("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator),
 		};
 	}
-
 }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/ColorConverter.cs
@@ -44,9 +44,7 @@ namespace FigmaSharp.NativeControls.Cocoa
 			{
 				var index = value.IndexOf("/");
 				if (index > -1)
-				{
 					value = value.Substring(index + 1);
-				}
 				var color = ThemeColors.FirstOrDefault(c => c.styleName == value).color;
 				return color;
 			}
@@ -79,58 +77,58 @@ namespace FigmaSharp.NativeControls.Cocoa
 			return null;
 		}
 
-		static IReadOnlyList<(string styleName, NSColor color, string nsColorName)> ThemeColors = new List<(string styleName, NSColor color, string nsColorName)>
-		{
-			// System color palette
-			//("System/Light/Red", NSColor.SystemRedColor, nameof (NSColor.SystemRedColor)),
-            //("System/Light/Green", NSColor.SystemGreenColor, nameof (NSColor.SystemGreenColor)),
-            //("System/Light/Blue", NSColor.SystemBlueColor, nameof ( NSColor.SystemBlueColor)),
-            //("System/Light/Orange", NSColor.SystemOrangeColor, nameof (NSColor.SystemOrangeColor)),
-            //("System/Light/Yellow", NSColor.SystemYellowColor, nameof (NSColor.SystemYellowColor)),
-            //("System/Light/Brown",NSColor.SystemBrownColor, nameof ( NSColor.SystemBrownColor)),
-            //("System/Light/Pink", NSColor.SystemPinkColor, nameof (NSColor.SystemPinkColor)),
-            //("System/Light/Purple", NSColor.SystemPurpleColor, nameof (NSColor.SystemPurpleColor)),
-            //("System/Teal", NSColor.SystemTealColor, nameof (NSColor.SystemTealColor)),
-			////("System/Indigo", NSColor.SystemIndigoColor), //breaks in mojave
-			//("System/Gray", NSColor.SystemGrayColor, nameof (NSColor.SystemGrayColor)),
+        static IReadOnlyList<(string styleName, NSColor color, string nsColorName)> ThemeColors = new List<(string styleName, NSColor color, string nsColorName)>
+        {
+            // System color palette
+            ("System/Light/Red", NSColor.SystemRedColor, nameof (NSColor.SystemRedColor)),
+            ("System/Light/Green", NSColor.SystemGreenColor, nameof (NSColor.SystemGreenColor)),
+            ("System/Light/Blue", NSColor.SystemBlueColor, nameof ( NSColor.SystemBlueColor)),
+            ("System/Light/Orange", NSColor.SystemOrangeColor, nameof (NSColor.SystemOrangeColor)),
+            ("System/Light/Yellow", NSColor.SystemYellowColor, nameof (NSColor.SystemYellowColor)),
+            ("System/Light/Brown",NSColor.SystemBrownColor, nameof ( NSColor.SystemBrownColor)),
+            ("System/Light/Pink", NSColor.SystemPinkColor, nameof (NSColor.SystemPinkColor)),
+            ("System/Light/Purple", NSColor.SystemPurpleColor, nameof (NSColor.SystemPurpleColor)),
+            ("System/Teal", NSColor.SystemTealColor, nameof (NSColor.SystemTealColor)),
+            ("System/Indigo", NSColor.SystemIndigoColor,  nameof ( NSColor.SystemIndigoColor)), //breaks in mojave
+            ("System/Gray", NSColor.SystemGrayColor, nameof (NSColor.SystemGrayColor)),
 
-			//// Text
-			//("Text/Label", NSColor.LabelColor, nameof ( NSColor.LabelColor)),
-			//("Text/Label Secondary", NSColor.SecondaryLabelColor, nameof (NSColor.SecondaryLabelColor)),
-			//("Text/Label Tertiary", NSColor.TertiaryLabelColor, nameof ( NSColor.TertiaryLabelColor)),
-			//("Text/Label Quaternary", NSColor.QuaternaryLabelColor, nameof ( NSColor.QuaternaryLabelColor)),
-			//("Text/Link", NSColor.LinkColor, nameof (NSColor.LinkColor)),
-			//("Text/Placeholder", NSColor.PlaceholderTextColor, nameof (NSColor.PlaceholderTextColor)),
-			//("Text/Window Frame", NSColor.WindowFrameText, nameof (NSColor.WindowFrameText)),
-			//("Text/Menu Item Selected", NSColor.SelectedMenuItemText, nameof (NSColor.SelectedMenuItemText)),
-			//("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText, nameof (NSColor.AlternateSelectedControlText)),
-			//("Text/Header", NSColor.HeaderText, nameof (NSColor.HeaderText)),
-			//("Text/Text", NSColor.Text, nameof (NSColor.Text)),
-			//("Text/Selected", NSColor.SelectedText, nameof (NSColor.SelectedText)),
-			//("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor, nameof (NSColor.UnemphasizedSelectedTextColor)),
-			//("Text/Control", NSColor.ControlText, nameof (NSColor.ControlText)),
-			//("Text/Control Selected", NSColor.SelectedControlText, nameof (NSColor.SelectedControlText)),
-			//("Text/Control Disabled", NSColor.DisabledControlText, nameof (NSColor.DisabledControlText)),
+            // Text
+            ("Text/Label", NSColor.LabelColor, nameof ( NSColor.LabelColor)),
+            ("Text/Label Secondary", NSColor.SecondaryLabelColor, nameof (NSColor.SecondaryLabelColor)),
+            ("Text/Label Tertiary", NSColor.TertiaryLabelColor, nameof ( NSColor.TertiaryLabelColor)),
+            ("Text/Label Quaternary", NSColor.QuaternaryLabelColor, nameof ( NSColor.QuaternaryLabelColor)),
+            ("Text/Link", NSColor.LinkColor, nameof (NSColor.LinkColor)),
+            ("Text/Placeholder", NSColor.PlaceholderTextColor, nameof (NSColor.PlaceholderTextColor)),
+            ("Text/Window Frame", NSColor.WindowFrameText, nameof (NSColor.WindowFrameText)),
+            ("Text/Menu Item Selected", NSColor.SelectedMenuItemText, nameof (NSColor.SelectedMenuItemText)),
+            ("Text/Control Selected Alternate", NSColor.AlternateSelectedControlText, nameof (NSColor.AlternateSelectedControlText)),
+            ("Text/Header", NSColor.HeaderText, nameof (NSColor.HeaderText)),
+            ("Text/Text", NSColor.Text, nameof (NSColor.Text)),
+            ("Text/Selected", NSColor.SelectedText, nameof (NSColor.SelectedText)),
+            ("Text/Selected Unemphasized", NSColor.UnemphasizedSelectedTextColor, nameof (NSColor.UnemphasizedSelectedTextColor)),
+            ("Text/Control", NSColor.ControlText, nameof (NSColor.ControlText)),
+            ("Text/Control Selected", NSColor.SelectedControlText, nameof (NSColor.SelectedControlText)),
+            ("Text/Control Disabled", NSColor.DisabledControlText, nameof (NSColor.DisabledControlText)),
 
-			// Chrome
-			//("Chrome/Separator", NSColor.SeparatorColor),
-			//("Chrome/Grid", NSColor.Grid),
-			//("Chrome/Text BG", NSColor.TextBackground),
-			//("Chrome/Text Selected BG", NSColor.SelectedTextBackground),
-			//("Chrome/Text Selected Unemphasized BG", NSColor.UnemphasizedSelectedTextBackgroundColor),
-			//("Chrome/Window BG", NSColor.WindowBackground),
-			//("Chrome/Under Page BG", NSColor.UnderPageBackgroundColor),
-			//("Chrome/Control BG", NSColor.ControlBackground),
-			//("Chrome/Content Selected BG", NSColor.SelectedContentBackgroundColor),
-			//("Chrome/Content Selected Unemphasized BG", NSColor.UnemphasizedSelectedContentBackgroundColor),
-			//("Chrome/Content Alternating BG", NSColor.AlternatingContentBackgroundColors[1]),
-			//("Chrome/Control", NSColor.Control),
-			//("Chrome/Control Selected", NSColor.SelectedControl),
-			//("Chrome/Control Accent", NSColor.ControlAccentColor),
+            // Chrome
+            ("Chrome/Separator", NSColor.SeparatorColor, nameof (NSColor.SeparatorColor)),
+            ("Chrome/Grid", NSColor.Grid, nameof (NSColor.Grid)),
+            ("Chrome/Text BG", NSColor.TextBackground, nameof (NSColor.TextBackground)),
+            ("Chrome/Text Selected BG", NSColor.SelectedTextBackground, nameof (NSColor.SelectedTextBackground)),
+            ("Chrome/Text Selected Unemphasized BG", NSColor.UnemphasizedSelectedTextBackgroundColor, nameof (NSColor.UnemphasizedSelectedTextBackgroundColor)),
+            ("Chrome/Window BG", NSColor.WindowBackground, nameof (NSColor.WindowBackground)),
+            ("Chrome/Under Page BG", NSColor.UnderPageBackgroundColor, nameof (NSColor.UnderPageBackgroundColor)),
+            ("Chrome/Control BG", NSColor.ControlBackground, nameof (NSColor.ControlBackground)),
+            ("Chrome/Content Selected BG", NSColor.SelectedContentBackgroundColor, nameof (NSColor.SelectedContentBackgroundColor)),
+            ("Chrome/Content Selected Unemphasized BG", NSColor.UnemphasizedSelectedContentBackgroundColor, nameof (NSColor.UnemphasizedSelectedContentBackgroundColor)),
+            ("Chrome/Content Alternating BG", NSColor.AlternatingContentBackgroundColors[1], $"AlternatingContentBackgroundColors[1]"),
+            ("Chrome/Control", NSColor.Control, nameof (NSColor.Control)),
+            ("Chrome/Control Selected", NSColor.SelectedControl, nameof (NSColor.SelectedControl)),
+            ("Chrome/Control Accent", NSColor.ControlAccentColor, nameof (NSColor.ControlAccentColor)),
 
-			//// Misc
-			//("Misc/Find Highlight", NSColor.FindHighlightColor),
-			//("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator),
-		};
+            // Misc
+            ("Misc/Find Highlight", NSColor.FindHighlightColor, nameof (NSColor.FindHighlightColor)),
+            ("Misc/Keyboard Focus Indicator", NSColor.KeyboardFocusIndicator, nameof (NSColor.KeyboardFocusIndicator))
+        };
 	}
 }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/LabelConverter.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Converters/LabelConverter.cs
@@ -86,7 +86,7 @@ namespace FigmaSharp.NativeControls.Cocoa
                     break;
             }
 
-			if (rendererService is FigmaViewRendererService rnd && figmaText.TryGetNSColorByStyleKey (rnd.FileProvider, rnd.colorConverter, FigmaStyle.Keys.Fill, out NSColor textColor))
+            if (rendererService is FigmaViewRendererService rnd && figmaText.TryGetNSColorByStyleKey (rnd.FileProvider, rnd.colorConverter, FigmaStyle.Keys.Fill, out NSColor textColor))
                 textField.TextColor = textColor;
 
             textField.Configure(figmaText, configureColor: false);

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Extensions.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Extensions.cs
@@ -23,6 +23,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+using System;
 using FigmaSharp.Models;
 using FigmaSharp.Services;
 
@@ -34,33 +35,47 @@ namespace FigmaSharp.NativeControls.Cocoa
 		{
 			foreach (var style in figmaText.styles)
 			{
-				if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
+				try
 				{
-					if (style.Key == styleKey)
+					if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
 					{
-						stringColor = colorConverter.FromStyleToStringColor(fillStyle.name);
-						return stringColor == null;
+						if (style.Key == styleKey)
+						{
+							stringColor = colorConverter.FromStyleToStringColor(fillStyle.name);
+							return stringColor == null;
+						}
+						continue;
 					}
-					continue;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine(ex);
 				}
 			}
 
 			stringColor = null;
 			return stringColor == null;
 		}
-	
-		public static bool TryGetNSColorByStyleKey (this FigmaText figmaText, IFigmaFileProvider fileProvider, IColorConverter colorConverter, string styleKey, out AppKit.NSColor color)
+
+		public static bool TryGetNSColorByStyleKey(this FigmaText figmaText, IFigmaFileProvider fileProvider, IColorConverter colorConverter, string styleKey, out AppKit.NSColor color)
 		{
 			foreach (var style in figmaText.styles)
 			{
-				if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
+				try
 				{
-					if (style.Key == styleKey)
+					if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
 					{
-						color = colorConverter.FromStyleToColor(fillStyle.name) as AppKit.NSColor;
-						return color != null;
+						if (style.Key == styleKey)
+						{
+							color = colorConverter.FromStyleToColor(fillStyle.name) as AppKit.NSColor;
+							return color != null;
+						}
+						continue;
 					}
-					continue;
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine(ex);
 				}
 			}
 			color = null;

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Extensions.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Extensions.cs
@@ -1,0 +1,70 @@
+﻿//
+// Author:
+//   jmedrano <josmed@microsoft.com>
+//
+// Copyright (C) 2020 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using FigmaSharp.Models;
+using FigmaSharp.Services;
+
+namespace FigmaSharp.NativeControls.Cocoa
+{
+	public static class Extensions
+	{
+		public static bool TryGetStringColorByStyleKey(this FigmaText figmaText, IFigmaFileProvider fileProvider, IColorConverter colorConverter, string styleKey, out string stringColor)
+		{
+			foreach (var style in figmaText.styles)
+			{
+				if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
+				{
+					if (style.Key == styleKey)
+					{
+						stringColor = colorConverter.FromStyleToStringColor(fillStyle.name);
+						return stringColor == null;
+					}
+					continue;
+				}
+			}
+
+			stringColor = null;
+			return stringColor == null;
+		}
+	
+		public static bool TryGetNSColorByStyleKey (this FigmaText figmaText, IFigmaFileProvider fileProvider, IColorConverter colorConverter, string styleKey, out AppKit.NSColor color)
+		{
+			foreach (var style in figmaText.styles)
+			{
+				if (fileProvider.TryGetStyle(style.Value, out FigmaStyle fillStyle))
+				{
+					if (style.Key == styleKey)
+					{
+						color = colorConverter.FromStyleToColor(fillStyle.name) as AppKit.NSColor;
+						return color != null;
+					}
+					continue;
+				}
+			}
+			color = null;
+			return color == null;
+		}
+	}
+}

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/FigmaNativeControlsDelegate.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/FigmaNativeControlsDelegate.cs
@@ -27,7 +27,6 @@
  */
 
 using System.Linq;
-
 using FigmaSharp.Cocoa;
 using FigmaSharp.Models;
 using FigmaSharp.NativeControls.Cocoa.Converters;
@@ -39,6 +38,8 @@ namespace FigmaSharp.NativeControls.Cocoa
 		static readonly FigmaCodePropertyConverterBase codePropertyConverter = new NativeControlsPropertyConverter ();
 
 		static readonly FigmaViewPropertySetterBase viewPropertySetter = new FigmaViewPropertySetter ();
+
+		static readonly IColorConverter colorConverter = new ColorConverter ();
 
 		static FigmaViewConverter[] allConverters;
 		static FigmaViewConverter[] converters;
@@ -99,5 +100,6 @@ namespace FigmaSharp.NativeControls.Cocoa
 
 		public FigmaViewPropertySetterBase GetViewPropertySetter() => viewPropertySetter;
 
+		public IColorConverter GetColorConverter() => colorConverter;
 	}
 }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/FigmaSharp.NativeControls.Cocoa.csproj
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/FigmaSharp.NativeControls.Cocoa.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PropertyConverters\FigmaCodeViewConverter.cs" />
     <Compile Include="FigmaContainerBundleWindow.cs" />
     <Compile Include="Converters\CustomViewCodeConverter.cs" />
+    <Compile Include="Extensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="figma.manifest">

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewCodeService.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewCodeService.cs
@@ -42,7 +42,7 @@ namespace FigmaSharp.Services
 
 		public NativeViewCodeService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null, FigmaCodePropertyConverterBase codePropertyConverter = null, IColorConverter colorConverter = null) : base (figmaProvider, figmaViewConverters ?? NativeControlsContext.Current.GetConverters(true),
 			codePropertyConverter ?? NativeControlsContext.Current.GetCodePropertyConverter (),
-			colorConverter)
+			colorConverter ?? NativeControlsContext.Current.GetColorConverter ())
 		{
 
 		}

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewCodeService.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewCodeService.cs
@@ -40,8 +40,9 @@ namespace FigmaSharp.Services
     {
 		public List<(string memberType, string name)> PrivateMembers = new List<(string memberType, string name)>();
 
-		public NativeViewCodeService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null, FigmaCodePropertyConverterBase codePropertyConverter = null) : base (figmaProvider, figmaViewConverters ?? NativeControlsContext.Current.GetConverters(true),
-			codePropertyConverter ?? NativeControlsContext.Current.GetCodePropertyConverter ())
+		public NativeViewCodeService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null, FigmaCodePropertyConverterBase codePropertyConverter = null, IColorConverter colorConverter = null) : base (figmaProvider, figmaViewConverters ?? NativeControlsContext.Current.GetConverters(true),
+			codePropertyConverter ?? NativeControlsContext.Current.GetCodePropertyConverter (),
+			colorConverter)
 		{
 
 		}

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
@@ -44,7 +44,7 @@ namespace FigmaSharp.Services
             : base (figmaProvider,
                   figmaViewConverters ?? NativeControlsContext.Current.GetConverters (),
                   propertySetter ?? NativeControlsContext.Current.GetViewPropertySetter(),
-                  colorConverter)
+                  colorConverter ?? NativeControlsContext.Current.GetColorConverter())
 		{
 
         }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
@@ -37,28 +37,28 @@ using FigmaSharp.Views;
 namespace FigmaSharp.Services
 {
     public class NativeViewRenderingService : FigmaViewRendererService
-	{
+    {
         public NativeViewRenderingService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null,
-			FigmaViewPropertySetterBase propertySetter = null,
-			IColorConverter colorConverter = null)
+            FigmaViewPropertySetterBase propertySetter = null,
+            IColorConverter colorConverter = null)
             : base (figmaProvider,
                   figmaViewConverters ?? NativeControlsContext.Current.GetConverters (),
                   propertySetter ?? NativeControlsContext.Current.GetViewPropertySetter(),
                   colorConverter ?? NativeControlsContext.Current.GetColorConverter())
-		{
+        {
 
         }
 
-		protected override IEnumerable<FigmaNode> GetCurrentChildren(FigmaNode currentNode, FigmaNode parentNode, CustomViewConverter converter, FigmaViewRendererServiceOptions options)
-		{
+        protected override IEnumerable<FigmaNode> GetCurrentChildren(FigmaNode currentNode, FigmaNode parentNode, CustomViewConverter converter, FigmaViewRendererServiceOptions options)
+        {
             var windowContent = currentNode.GetWindowContent();
             if (windowContent != null && windowContent is IFigmaNodeContainer nodeContainer) {
                 return nodeContainer.children;
             }
-			return base.GetCurrentChildren(currentNode, parentNode, converter, options);
-		}
+            return base.GetCurrentChildren(currentNode, parentNode, converter, options);
+        }
 
-		public override bool ProcessesImageFromNode (FigmaNode node)
+        public override bool ProcessesImageFromNode (FigmaNode node)
 		{
  			return node.IsImageNode () || node.IsFigmaImageViewNode ();
 		}

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls.Cocoa/Services/NativeViewRenderingService.cs
@@ -38,14 +38,16 @@ namespace FigmaSharp.Services
 {
     public class NativeViewRenderingService : FigmaViewRendererService
 	{
-		public NativeViewRenderingService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null, FigmaViewPropertySetterBase propertySetter = null)
+        public NativeViewRenderingService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null,
+			FigmaViewPropertySetterBase propertySetter = null,
+			IColorConverter colorConverter = null)
             : base (figmaProvider,
                   figmaViewConverters ?? NativeControlsContext.Current.GetConverters (),
-                  propertySetter ?? NativeControlsContext.Current.GetViewPropertySetter()
-                  )
+                  propertySetter ?? NativeControlsContext.Current.GetViewPropertySetter(),
+                  colorConverter)
 		{
 
-		}
+        }
 
 		protected override IEnumerable<FigmaNode> GetCurrentChildren(FigmaNode currentNode, FigmaNode parentNode, CustomViewConverter converter, FigmaViewRendererServiceOptions options)
 		{

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls/IFigmaNativeControlsDelegate.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls/IFigmaNativeControlsDelegate.cs
@@ -34,10 +34,10 @@ namespace FigmaSharp
 	{
 		FigmaBundleViewBase GetBundleView (FigmaBundle bundle, string name, FigmaNode figmaNode);
 
-        FigmaCodePropertyConverterBase GetCodePropertyConverter ();
+		FigmaCodePropertyConverterBase GetCodePropertyConverter ();
 
-        FigmaViewConverter[] GetConverters (bool includeAll = true);
-        FigmaViewPropertySetterBase GetViewPropertySetter();
+		FigmaViewConverter[] GetConverters (bool includeAll = true);
+		FigmaViewPropertySetterBase GetViewPropertySetter();
 
 		IColorConverter GetColorConverter();
 	}

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls/IFigmaNativeControlsDelegate.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls/IFigmaNativeControlsDelegate.cs
@@ -38,5 +38,7 @@ namespace FigmaSharp
 
         FigmaViewConverter[] GetConverters (bool includeAll = true);
         FigmaViewPropertySetterBase GetViewPropertySetter();
-    }
+
+		IColorConverter GetColorConverter();
+	}
 }

--- a/FigmaSharp.NativeControls/FigmaSharp.NativeControls/NativeControlsContext.cs
+++ b/FigmaSharp.NativeControls/FigmaSharp.NativeControls/NativeControlsContext.cs
@@ -64,8 +64,11 @@ namespace FigmaSharp
         public FigmaCodePropertyConverterBase GetCodePropertyConverter ()
             => figmaDelegate.GetCodePropertyConverter ();
 
+        public IColorConverter GetColorConverter()
+            => figmaDelegate.GetColorConverter();
+
         public FigmaViewConverter[] GetConverters (bool includeAll = true)
-             => figmaDelegate.GetConverters (includeAll);
+            => figmaDelegate.GetConverters (includeAll);
 
         #endregion
     }

--- a/FigmaSharp/FigmaSharp/FigmaModels.cs
+++ b/FigmaSharp/FigmaSharp/FigmaModels.cs
@@ -703,6 +703,10 @@ namespace FigmaSharp.Models
         [DisplayName ("Style")]
         public FigmaTypeStyle style { get; set; }
 
+        [Category("Text Data")]
+        [DisplayName("Styles")]
+        public Dictionary<string, string> styles { get; set; }
+
         [Category ("Text Data")]
         [DisplayName ("Character Style Overrides")]
         public int[] characterStyleOverrides { get; set; }

--- a/FigmaSharp/FigmaSharp/FigmaResponse.cs
+++ b/FigmaSharp/FigmaSharp/FigmaResponse.cs
@@ -34,14 +34,14 @@ using Newtonsoft.Json;
 
 namespace FigmaSharp.Models
 {
-	public class FigmaUser
-	{
-		public string handle { get; set; }
+    public class FigmaUser
+    {
+        public string handle { get; set; }
         public string img_url { get; set; }
         public string id { get; set; }
     }
 
-	public class FigmaFileVersion
+    public class FigmaFileVersion
     {
         public string id { get; set; }
         public DateTime created_at { get; set; }
@@ -54,8 +54,8 @@ namespace FigmaSharp.Models
         public bool IsNamed => !string.IsNullOrEmpty(label);
     }
 
-	public class FigmaFileVersionResponse
-	{
+    public class FigmaFileVersionResponse
+    {
         public FigmaFileVersion[] versions { get; set; }
     }
 
@@ -68,10 +68,10 @@ namespace FigmaSharp.Models
 
     public class FigmaStyle
     {
-		public class Keys
-		{
+        public class Keys
+        {
             public const string Fill = "fill";
-		}
+        }
 
         public string key { get; set; }
         public string name { get; set; }
@@ -95,16 +95,16 @@ namespace FigmaSharp.Models
         public int schemaVersion { get; set; }
 
 
-		public void Save (string filePath)
-		{
+        public void Save (string filePath)
+        {
             if (File.Exists (filePath)) {
                 File.Delete (filePath);
             }
             using (var file = File.CreateText (filePath)) {
-				var serializer = new JsonSerializer {
-					Formatting = Formatting.Indented
-				};
-				serializer.Serialize (file, this);
+                var serializer = new JsonSerializer {
+                    Formatting = Formatting.Indented
+                };
+                serializer.Serialize (file, this);
             }
         }
     }

--- a/FigmaSharp/FigmaSharp/FigmaResponse.cs
+++ b/FigmaSharp/FigmaSharp/FigmaResponse.cs
@@ -68,6 +68,11 @@ namespace FigmaSharp.Models
 
     public class FigmaStyle
     {
+		public class Keys
+		{
+            public const string Fill = "fill";
+		}
+
         public string key { get; set; }
         public string name { get; set; }
         public string styleType { get; set; }

--- a/FigmaSharp/FigmaSharp/IColorConverter.cs
+++ b/FigmaSharp/FigmaSharp/IColorConverter.cs
@@ -26,32 +26,12 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using System;
-using System.Reflection;
-
-using FigmaSharp.Views;
-
 namespace FigmaSharp
 {
-    public interface IFigmaDelegate
-    {
-        bool IsVerticalAxisFlipped { get; }
-
-        IView CreateEmptyView();
-        FigmaViewConverter[] GetFigmaConverters();
-
-        IImage GetImage(string url);
-		string GetSvgData(string url);
-
-		IImage GetImageFromFilePath(string filePath);
-        //FigmaResponse GetFigmaResponseFromContent(string template);
-        string GetManifestResource(Assembly assembly, string file);
-
-        IImage GetImageFromManifest(Assembly assembly, string imageRef);
-        IImageView GetImageView(IImage image);
-        void BeginInvoke(Action handler);
-        
-        FigmaCodePropertyConverterBase GetCodePropertyConverter ();
-        FigmaViewPropertySetterBase GetPropertySetter();
-    }
+	public interface IColorConverter
+	{
+		object FromStyle(object color);
+		object FromColor(object color);
+		object ToStringColor(object color);
+	}
 }

--- a/FigmaSharp/FigmaSharp/IColorConverter.cs
+++ b/FigmaSharp/FigmaSharp/IColorConverter.cs
@@ -30,8 +30,9 @@ namespace FigmaSharp
 {
 	public interface IColorConverter
 	{
-		object FromStyle(object color);
-		object FromColor(object color);
-		object ToStringColor(object color);
-	}
+        string FromColorToStyle(object color);
+        string FromStyleToStringColor(string style);
+        object FromStyleToColor(string colorStyleName);
+        object FromStringColorToStyle(object color);
+    }
 }

--- a/FigmaSharp/FigmaSharp/Services/FigmaCodeRendererService.cs
+++ b/FigmaSharp/FigmaSharp/Services/FigmaCodeRendererService.cs
@@ -9,6 +9,7 @@ namespace FigmaSharp.Services
 {
 	public class FigmaCodeRendererServiceOptions
 	{
+		public IColorConverter ColorConverter { get; set; }
 		public bool RendersConstructorFirstElement { get; set; }
 		public bool TranslateLabels { get; set; }
 	}

--- a/FigmaSharp/FigmaSharp/Services/FigmaCodeRendererService.cs
+++ b/FigmaSharp/FigmaSharp/Services/FigmaCodeRendererService.cs
@@ -9,7 +9,6 @@ namespace FigmaSharp.Services
 {
 	public class FigmaCodeRendererServiceOptions
 	{
-		public IColorConverter ColorConverter { get; set; }
 		public bool RendersConstructorFirstElement { get; set; }
 		public bool TranslateLabels { get; set; }
 	}
@@ -22,15 +21,18 @@ namespace FigmaSharp.Services
 
 		internal FigmaCodePropertyConverterBase codePropertyConverter;
 
+		internal IColorConverter colorConverter;
+
 		FigmaViewConverter[] figmaConverters;
 		FigmaViewConverter[] customConverters;
 
 		public FigmaCodeRendererService (IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters,
-			FigmaCodePropertyConverterBase codePropertyConverter)
+			FigmaCodePropertyConverterBase codePropertyConverter, IColorConverter colorConverter = null)
 		{
 			this.customConverters = figmaViewConverters.Where (s => !s.IsLayer).ToArray ();
 			this.figmaConverters = figmaViewConverters.Where (s => s.IsLayer).ToArray (); ;
 			this.figmaProvider = figmaProvider;
+			this.colorConverter = colorConverter;
 			this.codePropertyConverter = codePropertyConverter;
 		}
 

--- a/FigmaSharp/FigmaSharp/Services/FigmaFileProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/FigmaFileProvider.cs
@@ -60,6 +60,8 @@ namespace FigmaSharp.Services
 		FigmaNode FindByPath (params string[] path);
 		FigmaNode FindByName (string nodeName);
         bool TryGetMainComponent(FigmaInstance figmaInstance, out FigmaInstance outInstance);
+
+        bool TryGetStyle(string fillStyleValue, out FigmaStyle style);
     }
 
 	public class FigmaLocalFileProvider : FigmaFileProvider
@@ -413,5 +415,11 @@ namespace FigmaSharp.Services
 			result = null;
 			return false;
 		}
-    }
+
+        public bool TryGetStyle (string fillStyleValue, out FigmaStyle style)
+        {
+			return Response.styles.TryGetValue(fillStyleValue, out style);
+			// string.Format("{0}.{1}", typeof(NSColor), nameof(NSColor.SecondaryLabelColor)
+		}
+	}
 }

--- a/FigmaSharp/FigmaSharp/Services/FigmaFileProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/FigmaFileProvider.cs
@@ -416,8 +416,8 @@ namespace FigmaSharp.Services
 			return false;
 		}
 
-        public bool TryGetStyle (string fillStyleValue, out FigmaStyle style)
-        {
+		public bool TryGetStyle (string fillStyleValue, out FigmaStyle style)
+		{
 			return Response.styles.TryGetValue(fillStyleValue, out style);
 			// string.Format("{0}.{1}", typeof(NSColor), nameof(NSColor.SecondaryLabelColor)
 		}

--- a/FigmaSharp/FigmaSharp/Services/FigmaViewRendererService.cs
+++ b/FigmaSharp/FigmaSharp/Services/FigmaViewRendererService.cs
@@ -346,14 +346,16 @@ namespace FigmaSharp.Services
 
     public class FigmaViewRendererService : FigmaRendererService
     {
+        internal IColorConverter colorConverter;
+
         public FigmaViewPropertySetterBase PropertySetter { get; }
 
-        public FigmaViewRendererService(IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null) : this (figmaProvider, figmaViewConverters, AppContext.Current.GetPropertySetter ())
+        public FigmaViewRendererService(IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters = null, IColorConverter colorConverter = null) : this (figmaProvider, figmaViewConverters, AppContext.Current.GetPropertySetter ())
         {
-          
+            this.colorConverter = colorConverter;
         }
 
-        public FigmaViewRendererService(IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters, FigmaViewPropertySetterBase propertySetter) : base(figmaProvider, figmaViewConverters ?? AppContext.Current.GetFigmaConverters ())
+        public FigmaViewRendererService(IFigmaFileProvider figmaProvider, FigmaViewConverter[] figmaViewConverters, FigmaViewPropertySetterBase propertySetter, IColorConverter colorConverter = null) : base(figmaProvider, figmaViewConverters ?? AppContext.Current.GetFigmaConverters ())
         {
             this.PropertySetter = propertySetter;
         }

--- a/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
+++ b/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
@@ -61,9 +61,7 @@ namespace ToCode.Cocoa
 			fileProvider.Load (fileId);
 
 			var codePropertyConverter = NativeControlsContext.Current.GetCodePropertyConverter ();
-			var colorConverter = new ColorConverter();
-
-			codeRenderer = new NativeViewCodeService (fileProvider, converters, codePropertyConverter, colorConverter: colorConverter);
+			codeRenderer = new NativeViewCodeService (fileProvider, converters, codePropertyConverter);
 
 			data = new FigmaNodeView (fileProvider.Response.document);
 			figmaDelegate.ConvertToNodes (fileProvider.Response.document, data);

--- a/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
+++ b/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
@@ -61,7 +61,9 @@ namespace ToCode.Cocoa
 			fileProvider.Load (fileId);
 
 			var codePropertyConverter = NativeControlsContext.Current.GetCodePropertyConverter ();
-			codeRenderer = new NativeViewCodeService (fileProvider, converters, codePropertyConverter);
+			var colorConverter = new ColorConverter();
+
+			codeRenderer = new NativeViewCodeService (fileProvider, converters, codePropertyConverter, colorConverter: colorConverter);
 
 			data = new FigmaNodeView (fileProvider.Response.document);
 			figmaDelegate.ConvertToNodes (fileProvider.Response.document, data);
@@ -106,7 +108,10 @@ namespace ToCode.Cocoa
 			codeRenderer.Clear();
 			currentSelectedNode = e;
 			var builder = new StringBuilder ();
-			var options = new FigmaCodeRendererServiceOptions() { TranslateLabels = openUrlButton.State == NSCellStateValue.On };
+			var color = new ColorConverter();
+			var options = new FigmaCodeRendererServiceOptions() {
+				TranslateLabels = openUrlButton.State == NSCellStateValue.On,
+			};
 			codeRenderer.GetCode (builder, new FigmaCodeNode (e, null), null, options);
 			CopyToLogView (builder.ToString ());
 		}

--- a/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
+++ b/samples/FigmaSharp/ToCode/ToCode.Cocoa/ViewController.cs
@@ -106,7 +106,6 @@ namespace ToCode.Cocoa
 			codeRenderer.Clear();
 			currentSelectedNode = e;
 			var builder = new StringBuilder ();
-			var color = new ColorConverter();
 			var options = new FigmaCodeRendererServiceOptions() {
 				TranslateLabels = openUrlButton.State == NSCellStateValue.On,
 			};


### PR DESCRIPTION
This PR introduces the concept of IColorConverter into the RendererServices to allow handle styles from Figma API.

It can be used in any FigmaText to get the real NSColor from our ThemeColors dictionary.

Adds a first implementation in the LabelConverter.

- [ ] Add the all the correct names from our Layer spec (@hbons )
