### PR TITLE
WPF: Text improvements

### DIFF
--- a/FigmaSharp.Views/FigmaSharp.Views.Wpf/Extensions.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views.Wpf/Extensions.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Media;
 
-namespace FigmaSharp
+namespace FigmaSharp.Views.Wpf
 {
     public static class Extensions
     {

--- a/FigmaSharp.Views/FigmaSharp.Views/Extensions.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views/Extensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace FigmaSharp
+namespace FigmaSharp.Views
 {
 	public static class Extensions
 	{

--- a/FigmaSharp.Windows.sln
+++ b/FigmaSharp.Windows.sln
@@ -27,13 +27,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FigmaSharp.Wpf", "FigmaShar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicRendering.Wpf", "samples\FigmaSharp\BasicRendering\BasicRendering.Wpf\BasicRendering.Wpf.csproj", "{D19CA994-F936-418C-BE42-4699F80C651D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FigmaSharp.Tests", "tests\FigmaSharp.Tests.csproj", "{97A18BDA-8AA6-40E6-9928-B30B49C134E2}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FigmaFileExporter", "tools\FigmaFileExporter\FigmaFileExporter.csproj", "{316FE214-6944-457B-8060-BAA55D4B7309}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FigmaSharp.Views.Wpf", "FigmaSharp.Views\FigmaSharp.Views.Wpf\FigmaSharp.Views.Wpf.csproj", "{8BCCA4D3-0725-46B8-868D-BC56A8385A7B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FigmaSharp.Controls", "FigmaSharp.Controls\FigmaSharp.Controls\FigmaSharp.Controls.csproj", "{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FigmaSharp.Tests", "tests\FigmaSharp.Tests\FigmaSharp.Tests.csproj", "{97A18BDA-8AA6-40E6-9928-B30B49C134E2}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -141,24 +141,6 @@ Global
 		{D19CA994-F936-418C-BE42-4699F80C651D}.Release|iPhone.Build.0 = Release|Any CPU
 		{D19CA994-F936-418C-BE42-4699F80C651D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{D19CA994-F936-418C-BE42-4699F80C651D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|Any CPU.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|Any CPU.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhone.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhone.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhone.Build.0 = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{316FE214-6944-457B-8060-BAA55D4B7309}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{316FE214-6944-457B-8060-BAA55D4B7309}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{316FE214-6944-457B-8060-BAA55D4B7309}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -213,6 +195,24 @@ Global
 		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhone.Build.0 = Release|Any CPU
 		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|Any CPU.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhone.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhone.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.MacDebug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhone.Build.0 = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -224,8 +224,8 @@ Global
 		{32C47342-CF7F-4FE6-A3BA-E12E5BE126E5} = {FBBB8608-7B63-4C07-9609-16DDEB01C081}
 		{B523812B-9A7A-4D22-905E-878F93DC8FCF} = {FBBB8608-7B63-4C07-9609-16DDEB01C081}
 		{D19CA994-F936-418C-BE42-4699F80C651D} = {0F4964C7-A0DB-41E8-A8DE-01861F2FE09C}
-		{97A18BDA-8AA6-40E6-9928-B30B49C134E2} = {02319977-D222-4DA2-AE49-05EEF92B3DBF}
 		{316FE214-6944-457B-8060-BAA55D4B7309} = {CB8D35CB-1AA1-4D57-B8B5-E7A167A8CD35}
+		{97A18BDA-8AA6-40E6-9928-B30B49C134E2} = {02319977-D222-4DA2-AE49-05EEF92B3DBF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AF39AB59-9991-4134-A69A-4A88A5503FC7}

--- a/FigmaSharp.Windows.sln
+++ b/FigmaSharp.Windows.sln
@@ -7,8 +7,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{FBBB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicRendering.WinForms", "samples\basic-rendering\BasicRendering.WinForms\BasicRendering.WinForms.csproj", "{461B4A01-C603-4C8A-9763-642197569E9A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FigmaSharp.NativeControls", "FigmaSharp.NativeControls\FigmaSharp.NativeControls\FigmaSharp.NativeControls.csproj", "{E9891F05-7A3B-40A2-9388-505354D6D4C3}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BasicRendering", "BasicRendering", "{0F4964C7-A0DB-41E8-A8DE-01861F2FE09C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "LocalFile", "LocalFile", "{666C61C6-011C-407F-8D85-98DFD189651C}"
@@ -34,6 +32,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FigmaFileExporter", "tools\FigmaFileExporter\FigmaFileExporter.csproj", "{316FE214-6944-457B-8060-BAA55D4B7309}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FigmaSharp.Views.Wpf", "FigmaSharp.Views\FigmaSharp.Views.Wpf\FigmaSharp.Views.Wpf.csproj", "{8BCCA4D3-0725-46B8-868D-BC56A8385A7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FigmaSharp.Controls", "FigmaSharp.Controls\FigmaSharp.Controls\FigmaSharp.Controls.csproj", "{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -69,24 +69,6 @@ Global
 		{461B4A01-C603-4C8A-9763-642197569E9A}.Release|iPhone.Build.0 = Release|Any CPU
 		{461B4A01-C603-4C8A-9763-642197569E9A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{461B4A01-C603-4C8A-9763-642197569E9A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|Any CPU.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|iPhone.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|iPhone.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.MacDebug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|iPhone.Build.0 = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{E9891F05-7A3B-40A2-9388-505354D6D4C3}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{501083B2-B62E-4150-BC0F-5D049DFC6E42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{501083B2-B62E-4150-BC0F-5D049DFC6E42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{501083B2-B62E-4150-BC0F-5D049DFC6E42}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -213,6 +195,24 @@ Global
 		{8BCCA4D3-0725-46B8-868D-BC56A8385A7B}.Release|iPhone.Build.0 = Release|Any CPU
 		{8BCCA4D3-0725-46B8-868D-BC56A8385A7B}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{8BCCA4D3-0725-46B8-868D-BC56A8385A7B}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|Any CPU.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|iPhone.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|iPhone.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.MacDebug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhone.Build.0 = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{A138EB90-B46B-4928-A413-7F2E2C3E0CA5}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaFrameEntityConverter.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaFrameEntityConverter.cs
@@ -36,7 +36,7 @@ using FigmaSharp.Views.Wpf;
 
 namespace FigmaSharp.Wpf.Converters
 {
-    public class FigmaFrameEntityConverter : FigmaFrameEntityConverterBase
+    public class FigmaFrameEntityConverter : FigmaFrameConverterBase
     {
         public override Type GetControlType(FigmaNode currentNode) => typeof(CanvasImage);
 
@@ -49,7 +49,7 @@ namespace FigmaSharp.Wpf.Converters
                 view = new View();
 
             var currengroupView = view.NativeObject as FrameworkElement;
-            var figmaFrameEntity = (FigmaFrameEntity)currentNode;
+            var figmaFrameEntity = (FigmaFrame)currentNode;
             currengroupView.Configure(currentNode);
             
             // TODO: Resolve alpha, background color

--- a/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaFrameEntityConverter.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaFrameEntityConverter.cs
@@ -43,7 +43,7 @@ namespace FigmaSharp.Wpf.Converters
         public override IView ConvertTo(FigmaNode currentNode, ProcessedNode parent, FigmaRendererService rendererService)
         {
             IView view;
-            if (rendererService.ProcessesImageFromNode(currentNode))
+            if (rendererService.FileProvider.RendersAsImage(currentNode))
                 view = new ImageView();
             else
                 view = new View();

--- a/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaTextConverter.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaTextConverter.cs
@@ -38,14 +38,13 @@ namespace FigmaSharp.Wpf.Converters
 {
     public class FigmaTextConverter : FigmaTextConverterBase
     {
-        public override Type GetControlType(FigmaNode currentNode) => typeof(Label);
+        public override Type GetControlType(FigmaNode currentNode) => typeof(TextBlock);
 
         public override IView ConvertTo(FigmaNode currentNode, ProcessedNode parent, FigmaRendererService rendererService)
         {
             var figmaText = ((FigmaText)currentNode);
             
-            var textField = new Label(); 
-            textField.Content = figmaText.characters;
+            var textField = new TextBlock();  
             textField.Configure(figmaText);
             var wrapper = new View(textField);
             return wrapper;

--- a/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaTextConverter.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Converters/FigmaTextConverter.cs
@@ -32,7 +32,7 @@ using FigmaSharp.Models;
 using FigmaSharp.Views;
 using FigmaSharp.Services;
 using System;
-using FigmaSharp.Views.Wpf;
+using FigmaSharp.Views.Wpf; 
 
 namespace FigmaSharp.Wpf.Converters
 {
@@ -43,10 +43,8 @@ namespace FigmaSharp.Wpf.Converters
         public override IView ConvertTo(FigmaNode currentNode, ProcessedNode parent, FigmaRendererService rendererService)
         {
             var figmaText = ((FigmaText)currentNode);
-            //var font = figmaText.style.ToFont();
-            //var textField = new Label ();
-            var textField = new Label();
-            //textField.Font = font;
+            
+            var textField = new Label(); 
             textField.Content = figmaText.characters;
             textField.Configure(figmaText);
             var wrapper = new View(textField);
@@ -56,6 +54,6 @@ namespace FigmaSharp.Wpf.Converters
         public override string ConvertToCode(FigmaCodeNode currentNode, FigmaCodeNode parentNode, FigmaCodeRendererService rendererService)
         {
             return string.Empty;
-        }
+        } 
     }
 }

--- a/FigmaSharp/FigmaSharp.Wpf/Extensions/FigmaExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Extensions/FigmaExtensions.cs
@@ -26,17 +26,52 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 using System; 
-using System.Windows.Media;
-using System.Windows.Controls;
+using System.Windows.Media; 
 using System.Windows;
 using FigmaSharp.Models;
+using System.Windows.Documents;
+using System.Linq;
+using FigmaSharp.Views.Wpf;
 
 namespace FigmaSharp.Wpf
 {
     public static class FigmaExtensions
     {
         #region View Extensions
-          
+
+        public static void ConfigureStyle(this TextElement textElement, FigmaTypeStyle style)
+        {
+            string family = style.fontFamily;
+            if (family == "SF UI Text")
+            {
+                family = ".SF NS Text";
+            }
+            else if (family == "SF Mono")
+            {
+                family = ".SF NS Display";
+            }
+            else
+            {
+                Console.WriteLine("FONT: {0} - {1}", family, style.fontPostScriptName);
+            }
+            textElement.FontFamily = new FontFamily(family);
+
+            if(style.fontSize > 0)
+                textElement.FontSize = style.fontSize;// -3 ;
+
+            textElement.FontWeight = FontWeight.FromOpenTypeWeight(style.fontWeight);
+            if (style.letterSpacing != default)
+            {
+                textElement.FontStretch = FontStretch.FromOpenTypeStretch(style.letterSpacing > 9 ? 9 : (int)style.letterSpacing);
+            }
+
+            var fill = style.fills.FirstOrDefault();
+            if (fill != null)
+            {
+                textElement.Foreground = fill.color.ToColor();
+            }
+        }
+
         #endregion
     }
 }

--- a/FigmaSharp/FigmaSharp.Wpf/Extensions/FigmaExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Extensions/FigmaExtensions.cs
@@ -36,31 +36,7 @@ namespace FigmaSharp.Wpf
     public static class FigmaExtensions
     {
         #region View Extensions
-         
-        public static void ConfigureStyle (this Label label, FigmaTypeStyle style)
-        {
-            string family = style.fontFamily;
-            if (family == "SF UI Text")
-            {
-                family = ".SF NS Text";
-            }
-            else if (family == "SF Mono")
-            {
-                family = ".SF NS Display";
-            }
-            else
-            {
-                Console.WriteLine("FONT: {0} - {1}", family, style.fontPostScriptName);
-            }
-
-            var size = style.fontSize - 3;
-            var isBold = style.fontPostScriptName != null && style.fontPostScriptName.EndsWith("-Bold");
-
-            label.FontSize = size;
-            label.FontFamily = new FontFamily(family);
-            label.FontWeight = isBold ?  FontWeights.Bold : FontWeights.Regular;
-        }
-
+          
         #endregion
     }
 }

--- a/FigmaSharp/FigmaSharp.Wpf/Extensions/ViewConfigureExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Extensions/ViewConfigureExtensions.cs
@@ -10,7 +10,7 @@ namespace FigmaSharp.Wpf
 {
     public static class ViewConfigureExtensions
     {
-        public static void Configure(this FrameworkElement view, FigmaFrameEntity child)
+        public static void Configure(this FrameworkElement view, FigmaFrame child)
         {
             Configure(view, (FigmaNode)child);
             view.Opacity = child.opacity;

--- a/FigmaSharp/FigmaSharp.Wpf/Extensions/ViewConfigureExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Wpf/Extensions/ViewConfigureExtensions.cs
@@ -94,10 +94,30 @@ namespace FigmaSharp.Wpf
         {
             Configure(label, (FigmaNode)text);
 
-            label.ConfigureStyle(text.style);
+            label.HorizontalContentAlignment = text.style.textAlignHorizontal == "CENTER" ? HorizontalAlignment.Center : text.style.textAlignHorizontal == "LEFT" ? HorizontalAlignment.Left : HorizontalAlignment.Right;
+            label.VerticalContentAlignment = text.style.textAlignVertical == "CENTER" ? VerticalAlignment.Center : text.style.textAlignVertical == "TOP" ? VerticalAlignment.Top : VerticalAlignment.Bottom;
 
-            label.HorizontalAlignment = text.style.textAlignHorizontal == "CENTER" ? HorizontalAlignment.Center : text.style.textAlignHorizontal == "LEFT" ? HorizontalAlignment.Left : HorizontalAlignment.Right;
-            label.VerticalAlignment = text.style.textAlignVertical == "CENTER" ? VerticalAlignment.Center : text.style.textAlignVertical == "TOP" ? VerticalAlignment.Top : VerticalAlignment.Bottom;
+            label.HorizontalAlignment = HorizontalAlignment.Center;
+            string family = text.style.fontFamily;
+            if (family == "SF UI Text")
+            {
+                family = ".SF NS Text";
+            }
+            else if (family == "SF Mono")
+            {
+                family = ".SF NS Display";
+            }
+            else
+            {
+                Console.WriteLine("FONT: {0} - {1}", family, text.style.fontPostScriptName);
+            } 
+            label.FontFamily = new FontFamily(family);
+            label.FontSize = text.style.fontSize;// -3 ;
+            label.FontWeight = FontWeight.FromOpenTypeWeight(text.style.fontWeight);
+            if (text.style.letterSpacing > 0)
+            {
+                label.FontStretch = FontStretch.FromOpenTypeStretch(text.style.letterSpacing > 9 ? 9 : (int)text.style.letterSpacing);
+            }
 
             label.Opacity = text.opacity;
 
@@ -105,7 +125,7 @@ namespace FigmaSharp.Wpf
             if (fills != null)
             {
                 label.Foreground = fills.color.ToColor();
-            }
+            } 
         }
     }
 }

--- a/FigmaSharp/FigmaSharp.Wpf/FigmaSharp.Wpf.csproj
+++ b/FigmaSharp/FigmaSharp.Wpf/FigmaSharp.Wpf.csproj
@@ -31,10 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
+  <ItemGroup> 
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
@@ -82,12 +79,14 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="packages.config" />
+    </EmbeddedResource> 
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\FigmaSharp.Views\FigmaSharp.Views.Wpf\FigmaSharp.Views.Wpf.csproj">

--- a/FigmaSharp/FigmaSharp.Wpf/packages.config
+++ b/FigmaSharp/FigmaSharp.Wpf/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
-</packages>

--- a/FigmaSharp/FigmaSharp/Extensions/FigmaStyleExtensions.cs
+++ b/FigmaSharp/FigmaSharp/Extensions/FigmaStyleExtensions.cs
@@ -1,0 +1,59 @@
+﻿/* 
+ * FigmaStyleExtensions.cs - Extension methods for figma styles
+ * 
+ * Author:
+ *   Jose Medrano <josmed@microsoft.com>
+ *
+ * Copyright (C) 2018 Microsoft, Corp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using FigmaSharp.Models; 
+
+namespace FigmaSharp.Extensions
+{
+    public static class FigmaStyleExtensions
+    {
+        public static void FillEmptyStylePropertiesWithDefaults(this FigmaTypeStyle style, FigmaText text)
+        {
+            if (style.fills == default)
+                style.fills = text.fills;
+            if (style.fontFamily == default)
+                style.fontFamily = text.style.fontFamily;
+            if (style.fontPostScriptName == default)
+                style.fontPostScriptName = text.style.fontPostScriptName;
+            if (style.fontSize == default)
+                style.fontSize = text.style.fontSize;
+            if (style.fontWeight == default)
+                style.fontWeight = text.style.fontWeight;
+            if (style.letterSpacing == default)
+                style.letterSpacing = text.style.letterSpacing;
+            if (style.lineHeightPercent == default)
+                style.lineHeightPercent = text.style.lineHeightPercent;
+            if (style.lineHeightPx == default)
+                style.lineHeightPx = text.style.lineHeightPx;
+            if (style.textAlignHorizontal == default)
+                style.textAlignHorizontal = text.style.textAlignHorizontal;
+            if (style.textAlignVertical == default)
+                style.textAlignVertical = text.style.textAlignVertical;
+        }
+    }
+}

--- a/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
+++ b/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
@@ -27,10 +27,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="Newtonsoft.Json">
-          <Version>12.0.1</Version>
-        </PackageReference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.1</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeGeneratorTests.cs" />
@@ -38,23 +38,23 @@
     <Compile Include="LocalFileTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\FigmaSharp\FigmaSharp\FigmaSharp.csproj">
-      <Project>{11142FD4-8D40-4724-883A-52E9A84A099B}</Project>
-      <Name>FigmaSharp</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\FigmaSharp.Views\FigmaSharp.Views\FigmaSharp.Views.csproj">
-      <Project>{9B7E2FF6-7A25-4903-9774-1C0FB56B2B19}</Project>
-      <Name>FigmaSharp.Views</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\FigmaSharp.Controls\FigmaSharp.Controls\FigmaSharp.Controls.csproj">
-      <Project>{A8372FD9-04BB-41F0-85C8-CBAB9E587501}</Project>
-      <Name>FigmaSharp.Controls</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="test.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\FigmaSharp.Controls\FigmaSharp.Controls\FigmaSharp.Controls.csproj">
+      <Project>{a138eb90-b46b-4928-a413-7f2e2c3e0ca5}</Project>
+      <Name>FigmaSharp.Controls</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\FigmaSharp.Views\FigmaSharp.Views\FigmaSharp.Views.csproj">
+      <Project>{558ecd10-2dd2-4e41-b07b-cbf755c80486}</Project>
+      <Name>FigmaSharp.Views</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\FigmaSharp\FigmaSharp\FigmaSharp.csproj">
+      <Project>{501083b2-b62e-4150-bc0f-5d049dfc6e42}</Project>
+      <Name>FigmaSharp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Summary of the changes:
- Fix breaking changes
- Replaced `Label` -> `TextBlock`
- Added support for style overrides in a text
- Modified a few namespaces for extension classes (otherwise they'd collide in using statements)
- Use PackageReferences in FigmaSharp.Wpf

Last but not least:
- Added an extension method for curating the Text's style properties: `FigmaStyleExtensions`. What Figma's API exposes is the "default" style in the `Text` node, and then the override styles  only have values for the properties that actually change. In the case of WPF this isn't very friendly, as we apply the style and construct the text at the same time. So what I'm doing is patching that model before processing (filling all the blanks). Please feel free to ask for a different approach if you've solved this in a different approach elsewhere :)