### PR TITLE
[Extension] Uses NodeCustomName instead NodeId to update the dialogs generated

### DIFF
--- a/FigmaSharp/FigmaSharp/FigmaFile/FigmaFile.cs
+++ b/FigmaSharp/FigmaSharp/FigmaFile/FigmaFile.cs
@@ -44,7 +44,7 @@ namespace FigmaSharp
     public class FigmaFile : IFigmaFile
     {
         public const string FigmaPackageId = "FigmaPackageId";
-        public const string FigmaNodeId = "FigmaNodeId";
+        public const string FigmaNodeCustomName = "FigmaNodeCustomName";
 
         /// <summary>
         /// Gets the figma images.

--- a/FigmaSharp/FigmaSharp/Services/Providers/NodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/NodeProvider.cs
@@ -140,6 +140,16 @@ namespace FigmaSharp.Services
 			return Nodes.FirstOrDefault (s => s.name == name);
 		}
 
+		public FigmaNode FindByCustomName(string name)
+		{
+			var found = Nodes.FirstOrDefault(s => s.TryGetNodeCustomName (out var customName) && customName == name);
+			if (found != null)
+			{
+				return found;
+			}
+			return Nodes.FirstOrDefault(s => s.name == name);
+		}
+
 		void ProcessNodeRecursively (FigmaNode node, FigmaNode parent)
 		{
 			node.Parent = parent;

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
@@ -137,7 +137,11 @@ namespace MonoDevelop.Figma
 			var csProjectFile = currentProject.AddFile(publicCsClassFilePath);
 			designerProjectFile.DependsOn = csProjectFile.FilePath;
 			designerProjectFile.Metadata.SetValue(FigmaFile.FigmaPackageId, bundle.FileId);
-			designerProjectFile.Metadata.SetValue(FigmaFile.FigmaNodeId, figmaBundleView.FigmaNode.id);
+
+			if (!figmaBundleView.FigmaNode.TryGetNodeCustomName(out string customName))
+				customName = figmaBundleView.FigmaNode.name;
+
+			designerProjectFile.Metadata.SetValue(FigmaFile.FigmaNodeCustomName, customName);
 			return csProjectFile;
 		}
 

--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Figma
 
 		public static bool TryGetNodeName (this ProjectFile sender, out string nodeName)
 		{
-			nodeName = sender.Metadata.GetValue(FigmaFile.FigmaNodeId, null);
+			nodeName = sender.Metadata.GetValue(FigmaFile.FigmaNodeCustomName, null);
 			return !string.IsNullOrEmpty (nodeName);
 		}
 
@@ -56,7 +56,7 @@ namespace MonoDevelop.Figma
 		public static bool TryGetFigmaNode (this ProjectFile sender, NodeProvider fileProvider, out FigmaNode figmaNode)
 		{
 			if (sender.IsFigmaDesignerFile () && TryGetNodeName (sender,out var figmaName)) {
-				figmaNode = fileProvider.FindById (figmaName);
+				figmaNode = fileProvider.FindByCustomName (figmaName);
 				return figmaNode != null;
             }
 			figmaNode = null;
@@ -89,7 +89,11 @@ namespace MonoDevelop.Figma
                 partialFilePath.DependsOn = figmaBundleView.PublicCsClassFilePath;
 
                 partialFilePath.Metadata.SetValue(FigmaFile.FigmaPackageId, figmaBundleView.Bundle.FileId);
-				partialFilePath.Metadata.SetValue(FigmaFile.FigmaNodeId, figmaBundleView.FigmaNode.id);
+
+				if (!figmaBundleView.FigmaNode.TryGetNodeCustomName (out var customName)) {
+					customName = figmaBundleView.FigmaNode.name;
+				}
+				partialFilePath.Metadata.SetValue(FigmaFile.FigmaNodeCustomName, customName);
 			}
 
             if (savesInProject)


### PR DESCRIPTION
Uses NodeCustomName instead NodeId to update the dialogs generated

Fixes #272 