### PR TITLE
More features to get a beautiful flexible layout

### DIFF
--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/CocoaConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/CocoaConverter.cs
@@ -39,6 +39,8 @@ namespace FigmaSharp.Controls.Cocoa
 {
 	public abstract class CocoaConverter : NodeConverter
 	{
+		internal override bool HasHeightConstraint() => false;
+
 		public override bool ScanChildren(FigmaNode currentNode)
 		{
 			return false;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/CocoaConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/CocoaConverter.cs
@@ -39,8 +39,6 @@ namespace FigmaSharp.Controls.Cocoa
 {
 	public abstract class CocoaConverter : NodeConverter
 	{
-		internal override bool HasHeightConstraint() => false;
-
 		public override bool ScanChildren(FigmaNode currentNode)
 		{
 			return false;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/BoxConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/BoxConverter.cs
@@ -41,8 +41,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class BoxConverter : CocoaConverter
     {
-        internal override bool HasHeightConstraint() => true;
-
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSBox);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/BoxConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/BoxConverter.cs
@@ -41,8 +41,9 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class BoxConverter : CocoaConverter
     {
-        public override Type GetControlType(FigmaNode currentNode) => typeof(NSBox);
+        internal override bool HasHeightConstraint() => true;
 
+        public override Type GetControlType(FigmaNode currentNode) => typeof(NSBox);
 
         public override bool CanConvert(FigmaNode currentNode)
         {

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ButtonConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ButtonConverter.cs
@@ -40,6 +40,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class ButtonConverter : CocoaConverter
     {
+        internal override bool HasHeightConstraint() => false;
+
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSButton);
 
         internal override bool IsFlexibleHorizontal(FigmaNode node) => true;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/CheckBoxConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/CheckBoxConverter.cs
@@ -48,7 +48,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
                 controlType == FigmaControlType.CheckBox;
         }
 
-
         protected override IView OnConvertToView (FigmaNode currentNode, ViewNode parentNode, ViewRenderService rendererService)
         {
             var frame = (FigmaFrame)currentNode;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/CheckBoxConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/CheckBoxConverter.cs
@@ -40,6 +40,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class CheckBoxConverter : CocoaConverter
     {
+        internal override bool HasHeightConstraint() => false;
+
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSButton);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ColorWellConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ColorWellConverter.cs
@@ -40,6 +40,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
 	public class ColorWellConverter : CocoaConverter
 	{
+		internal override bool HasHeightConstraint() => false;
+
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSColorWell);
 
 		public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ComboBoxConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ComboBoxConverter.cs
@@ -41,6 +41,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class ComboBoxConverter : CocoaConverter
 	{
+		internal override bool HasHeightConstraint() => false;
+
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSComboBox);
 
 		public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/DisclosureViewConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/DisclosureViewConverter.cs
@@ -39,14 +39,13 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class DisclosureViewConverter : CocoaConverter
 	{
-		public override Type GetControlType(FigmaNode currentNode) => typeof(NSView);
+        public override Type GetControlType(FigmaNode currentNode) => typeof(NSView);
 
 		public override bool CanConvert(FigmaNode currentNode)
 		{
 			return currentNode.TryGetNativeControlType(out var controlType) &&
                 controlType == FigmaControlType.DisclosureView;
 		}
-
 
 		protected override IView OnConvertToView(FigmaNode currentNode, ViewNode parentNode, ViewRenderService rendererService)
 		{

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/DisclosureViewConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/DisclosureViewConverter.cs
@@ -39,7 +39,9 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class DisclosureViewConverter : CocoaConverter
 	{
-        public override Type GetControlType(FigmaNode currentNode) => typeof(NSView);
+		internal override bool HasHeightConstraint() => false;
+
+		public override Type GetControlType(FigmaNode currentNode) => typeof(NSView);
 
 		public override bool CanConvert(FigmaNode currentNode)
 		{

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/LabelConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/LabelConverter.cs
@@ -41,6 +41,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class LabelConverter : CocoaConverter
     {
+        internal override bool HasHeightConstraint() => true;
+
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSTextField);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/LabelConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/LabelConverter.cs
@@ -41,8 +41,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class LabelConverter : CocoaConverter
     {
-        internal override bool HasHeightConstraint() => true;
-
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSTextField);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/PopUpButtonConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/PopUpButtonConverter.cs
@@ -38,6 +38,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class PopUpButtonConverter : CocoaConverter
 	{
+		internal override bool HasHeightConstraint() => false;
+
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSPopUpButton);
 
 		public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ProgressIndicatorConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ProgressIndicatorConverter.cs
@@ -38,6 +38,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
 	public abstract class ProgressIndicatorConverter : CocoaConverter
     {
+		internal override bool HasHeightConstraint() => false;
+
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSProgressIndicator);
 
 		protected override IView OnConvertToView(FigmaNode currentNode, ViewNode parentNode, ViewRenderService rendererService)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ProgressIndicatorConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/ProgressIndicatorConverter.cs
@@ -40,7 +40,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
     {
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSProgressIndicator);
 
-
 		protected override IView OnConvertToView(FigmaNode currentNode, ViewNode parentNode, ViewRenderService rendererService)
 		{
 			var frame = (FigmaFrame)currentNode;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/RadioConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/RadioConverter.cs
@@ -38,6 +38,7 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
 	public class RadioConverter : CocoaConverter
 	{
+        internal override bool HasHeightConstraint() => false;
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSButton);
 
 		public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SegmentedControlConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SegmentedControlConverter.cs
@@ -38,6 +38,7 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class SegmentedControlConverter : CocoaConverter
     {
+        internal override bool HasHeightConstraint() => false;
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSSegmentedControl);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SliderConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SliderConverter.cs
@@ -40,7 +40,7 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
 	public abstract class SliderConverter : CocoaConverter
     {
-		public override Type GetControlType(FigmaNode currentNode) => typeof(NSSlider);
+        public override Type GetControlType(FigmaNode currentNode) => typeof(NSSlider);
 
 		public override bool CanSetAccessibilityLabel => false;
 

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SwitchConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/SwitchConverter.cs
@@ -37,6 +37,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class SwitchConverter : CocoaConverter
     {
+        internal override bool HasHeightConstraint() => false;
+
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSSwitch);
 
         public override bool CanSetAccessibilityLabel => false;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TabViewConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TabViewConverter.cs
@@ -39,8 +39,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class TabViewConverter : CocoaConverter
     {
-        internal override bool HasHeightConstraint() => true;
-
         public override Type GetControlType(FigmaNode currentNode) => typeof(NSTabView);
 
         public override bool CanConvert(FigmaNode currentNode)

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TabViewConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TabViewConverter.cs
@@ -39,8 +39,9 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class TabViewConverter : CocoaConverter
     {
-        public override Type GetControlType(FigmaNode currentNode) => typeof(NSTabView);
+        internal override bool HasHeightConstraint() => true;
 
+        public override Type GetControlType(FigmaNode currentNode) => typeof(NSTabView);
 
         public override bool CanConvert(FigmaNode currentNode)
         {

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TextFieldConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/TextFieldConverter.cs
@@ -38,6 +38,8 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
     public class TextFieldConverter : CocoaConverter
 	{
+		internal override bool HasHeightConstraint() => false;
+
 		public override Type GetControlType(FigmaNode currentNode)
 		{
 			FigmaNode optionsGroup = currentNode.Options();

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/WindowConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Controls/WindowConverter.cs
@@ -77,7 +77,6 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 		}
 	}
 
-
 	public class WindowPanelConverter : CocoaConverter
 	{
 		public override Type GetControlType(FigmaNode currentNode) => typeof(NSPanel);

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Misc/CustomViewCodeConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Misc/CustomViewCodeConverter.cs
@@ -35,7 +35,9 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 {
 	public class CustomViewConverter : CocoaConverter
 	{
-		public override Type GetControlType(FigmaNode currentNode)
+		internal override bool HasHeightConstraint() => true;
+
+        public override Type GetControlType(FigmaNode currentNode)
 		{
 			var customType = GetIdentifierValue(currentNode.name, "type", true);
 			if (customType != null) {

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/AccessibilityNodeExtensions.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/AccessibilityNodeExtensions.cs
@@ -25,6 +25,8 @@
 
 using System;
 using System.Linq;
+
+using FigmaSharp.Cocoa;
 using FigmaSharp.Models;
 
 namespace FigmaSharp.Controls.Cocoa

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
@@ -293,54 +293,6 @@ namespace FigmaSharp.Controls.Cocoa
             return figmaNode.FirstChild(s => s.name == "!options");
         }
 
-        public static bool TryGetAttributeValue(this FigmaNode node, string parameter, out string value)
-        {
-            //we want remove special chars
-            parameter = FigmaSharp.ServiceExtensions.FilterName (parameter);
-
-            value = node.name;
-            try
-            {
-                var index = value.IndexOf(parameter);
-                if (index > -1 && index < value.Length)
-                {
-                    value = value.Substring(index + parameter.Length);
-                    index = value.IndexOf("\"");
-                    if (index > -1 && index < value.Length)
-                    {
-                        value = value.Substring(index + 1);
-                        index = value.IndexOf("\"");
-                        if (index > -1 && index < value.Length)
-                        {
-                            value = value.Substring(0, index);
-                            return true;
-                        }
-                    }
-                }
-            }
-            catch (Exception)
-            {
-            }
-            value = null;
-            return false;
-        }
-
-        public static bool TryGetChildPropertyValue(this FigmaNode node, string property, out string value)
-        {
-            if (node is IFigmaNodeContainer container && container.children != null)
-            {
-                foreach (var item in container.children)
-                {
-                    if (TryGetAttributeValue(item, property, out value))
-                    {
-                        return true;
-                    }
-                }
-            }
-            value = null;
-            return false;
-        }
-
         //public static NativeControlComponentType ToControlType (this FigmaInstance figmaInstance)
         //{
         //    if (figmaInstance.Component != null) {

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlCodeRendererService.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlCodeRendererService.cs
@@ -175,23 +175,65 @@ namespace FigmaSharp.Controls.Cocoa.Services
 			return base.RendersConstraints(node, parent, rendererService);
 		}
 
+
+		#endregion
+
+
+		#region Flexible Views
 		const string IsFlexibleHorizontalParameter = "isFlexibleHorizontal";
 		const string IsFlexibleVerticalParameter = "isFlexibleVertical";
 
-		internal override bool IsFlexibleHorizontal(CodeNode codeNode, NodeConverter converter)
-        {
-			if (codeNode.Node.TryGetAttributeValue(IsFlexibleHorizontalParameter, out var value) && value == "true")
-				return true;
-            return base.IsFlexibleHorizontal(codeNode, converter);
+		internal override bool IsFlexibleHorizontal(ContainerNode currentNode, NodeConverter converter)
+		{
+			if (currentNode.Node.TryGetAttributeValue(IsFlexibleHorizontalParameter, out var value))
+			{
+				if (value == "true")
+					return true;
+				if (value == "false")
+					return false;
+			}
+			return base.IsFlexibleHorizontal(currentNode, converter);
 		}
-	
-		internal override bool IsFlexibleVertical(CodeNode codeNode, NodeConverter converter)
-        {
-			if (codeNode.Node.TryGetAttributeValue(IsFlexibleVerticalParameter, out var value) && value == "true")
-				return true;
-			return base.IsFlexibleVertical(codeNode, converter);
-        }
 
-        #endregion
-    }
+		internal override bool IsFlexibleVertical(ContainerNode currentNode, NodeConverter converter)
+		{
+			if (currentNode.Node.TryGetAttributeValue(IsFlexibleVerticalParameter, out var value))
+			{
+				if (value == "true")
+					return true;
+				if (value == "false")
+					return false;
+			}
+			return base.IsFlexibleVertical(currentNode, converter);
+		}
+
+		const string HasWidthConstraintParameter = "hasWidthConstraint";
+		const string HasHeightConstraintParameter = "hasHeightConstraint";
+
+		internal override bool HasHeightConstraint(FigmaNode currentNode, NodeConverter converter)
+		{
+			if (currentNode.TryGetAttributeValue(HasHeightConstraintParameter, out var value))
+			{
+				if (value == "true")
+					return true;
+				if (value == "false")
+					return false;
+			}
+			return base.HasHeightConstraint(currentNode, converter);
+		}
+
+		internal override bool HasWidthConstraint(FigmaNode currentNode, NodeConverter converter)
+		{
+			if (currentNode.TryGetAttributeValue(HasWidthConstraintParameter, out var value))
+			{
+				if (value == "true")
+					return true;
+				if (value == "false")
+					return false;
+			}
+			return base.HasWidthConstraint(currentNode, converter);
+		}
+
+		#endregion
+	}
 }

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlCodeRendererService.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlCodeRendererService.cs
@@ -29,6 +29,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using FigmaSharp.Cocoa;
 using FigmaSharp.Converters;
 using FigmaSharp.Models;
 using FigmaSharp.PropertyConfigure;
@@ -175,9 +176,7 @@ namespace FigmaSharp.Controls.Cocoa.Services
 			return base.RendersConstraints(node, parent, rendererService);
 		}
 
-
 		#endregion
-
 
 		#region Flexible Views
 		const string IsFlexibleHorizontalParameter = "isFlexibleHorizontal";

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlViewRenderingService.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlViewRenderingService.cs
@@ -92,9 +92,9 @@ namespace FigmaSharp.Controls.Cocoa.Services
 
         protected override bool RendersConstraints(ViewNode currentNode, ViewNode parentNode, RenderService rendererService)
         {
-            if (currentNode.FigmaNode.IsDialogParentContainer())
+            if (currentNode.Node.IsDialogParentContainer())
                 return false;
-            if (currentNode.FigmaNode.IsNodeWindowContent())
+            if (currentNode.Node.IsNodeWindowContent())
                 return false;
             return base.RendersConstraints (currentNode, parentNode, rendererService);
         }
@@ -130,13 +130,73 @@ namespace FigmaSharp.Controls.Cocoa.Services
 			return false;
 		}
 
+        #region Flexible Views
+
+        const string HasWidthConstraintParameter = "hasWidthConstraint";
+        const string HasHeightConstraintParameter = "hasHeightConstraint";
+
+        const string IsFlexibleHorizontalParameter = "isFlexibleHorizontal";
+        const string IsFlexibleVerticalParameter = "isFlexibleVertical";
+
+        internal override bool IsFlexibleHorizontal(ContainerNode currentNode, NodeConverter converter)
+        {
+            if (currentNode.Node.TryGetAttributeValue(IsFlexibleHorizontalParameter, out var value))
+            {
+                if (value == "true")
+                    return true;
+                if (value == "false")
+                    return false;
+            }
+            return base.IsFlexibleHorizontal(currentNode, converter);
+        }
+
+        internal override bool IsFlexibleVertical(ContainerNode currentNode, NodeConverter converter)
+        {
+            if (currentNode.Node.TryGetAttributeValue(IsFlexibleVerticalParameter, out var value))
+            {
+                if (value == "true")
+                    return true;
+                if (value == "false")
+                    return false;
+            }
+            return base.IsFlexibleVertical(currentNode, converter);
+        }
+
+        internal override bool HasHeightConstraint(FigmaNode currentNode, NodeConverter converter)
+        {
+            if (currentNode.TryGetAttributeValue(HasHeightConstraintParameter, out var value))
+            {
+                if (value == "true")
+                    return true;
+                if (value == "false")
+                    return false;
+            }
+            return base.HasHeightConstraint(currentNode, converter);
+        }
+
+        internal override bool HasWidthConstraint(FigmaNode currentNode, NodeConverter converter)
+        {
+            if (currentNode.TryGetAttributeValue(HasWidthConstraintParameter, out var value))
+            {
+                if (value == "true")
+                    return true;
+                if (value == "false")
+                    return false;
+            }
+            return base.HasWidthConstraint(currentNode, converter);
+        }
+
+        #endregion
+
+
+
         internal ViewNode[] GetProcessedNodes(FigmaNode[] mainNodes)
 		{
             ViewNode[] resultNodes = new ViewNode[mainNodes.Length];
 			for (int i = 0; i < mainNodes.Length; i++)
 			{
                 var currentNode = mainNodes[i];
-                resultNodes[i] = NodesProcessed.FirstOrDefault(s => s.FigmaNode == currentNode);
+                resultNodes[i] = NodesProcessed.FirstOrDefault(s => s.Node == currentNode);
             }
             return resultNodes;
 		}

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlViewRenderingService.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Services/ControlViewRenderingService.cs
@@ -28,6 +28,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using FigmaSharp.Cocoa;
 using FigmaSharp.Converters;
 using FigmaSharp.Models;
 using FigmaSharp.PropertyConfigure;
@@ -187,8 +188,6 @@ namespace FigmaSharp.Controls.Cocoa.Services
         }
 
         #endregion
-
-
 
         internal ViewNode[] GetProcessedNodes(FigmaNode[] mainNodes)
 		{

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/StackViewConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/StackViewConverter.cs
@@ -26,6 +26,8 @@ using System;
 using System.Text;
 
 using AppKit;
+
+using FigmaSharp.Cocoa;
 using FigmaSharp.Converters;
 using FigmaSharp.Models;
 using FigmaSharp.Services;
@@ -70,10 +72,17 @@ namespace FigmaSharp.Cocoa.Converters
 
             if (propertyName == Properties.Distribution)
             {
-                stackView.Distribution = NSStackViewDistribution.Fill;
+                node.TryGetAttributeValue (DistributionPropertyName, out var value);
+
+                NSStackViewDistribution distribution = NSStackViewDistribution.Fill;
+                if (!string.IsNullOrEmpty (value))
+                    Enum.TryParse(value.ToCamelCase(), out distribution);
+                stackView.Distribution = distribution;
                 return;
             }
         }
+
+        const string DistributionPropertyName = "distribution";
 
         public override IView ConvertToView (FigmaNode currentNode, ViewNode parent, ViewRenderService rendererService)
         {
@@ -118,7 +127,15 @@ namespace FigmaSharp.Cocoa.Converters
 
             if (propertyName == Properties.Distribution)
             {
-                code.WritePropertyEquality(codeNode.Name, nameof(NSStackView.Distribution), NSStackViewDistribution.Fill.GetFullName());
+                codeNode.Node.TryGetAttributeValue(DistributionPropertyName, out var value);
+                NSStackViewDistribution distribution = NSStackViewDistribution.Fill;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    var parameter = typeof(NSStackViewDistribution).WithProperty(value.ToCamelCase());
+                    Enum.TryParse(parameter, out distribution); ;
+                }
+
+                code.WritePropertyEquality(codeNode.Name, nameof(NSStackView.Distribution), distribution.GetFullName());
                 return;
             }
         }

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/StackViewConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/StackViewConverter.cs
@@ -70,7 +70,7 @@ namespace FigmaSharp.Cocoa.Converters
 
             if (propertyName == Properties.Distribution)
             {
-                stackView.Distribution = NSStackViewDistribution.FillEqually;
+                stackView.Distribution = NSStackViewDistribution.Fill;
                 return;
             }
         }
@@ -118,7 +118,7 @@ namespace FigmaSharp.Cocoa.Converters
 
             if (propertyName == Properties.Distribution)
             {
-                code.WritePropertyEquality(codeNode.Name, nameof(NSStackView.Distribution), NSStackViewDistribution.FillEqually.GetFullName());
+                code.WritePropertyEquality(codeNode.Name, nameof(NSStackView.Distribution), NSStackViewDistribution.Fill.GetFullName());
                 return;
             }
         }

--- a/FigmaSharp/FigmaSharp.Cocoa/Extensions/CodeGenerationExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Extensions/CodeGenerationExtensions.cs
@@ -7,6 +7,11 @@ namespace FigmaSharp.Cocoa
 {
 	public static class CodeGenerationExtensions
 	{
+		public static string GetFullProperty (this Enum enumeration, string property)
+		{
+			return enumeration.GetType().WithProperty(property.ToCamelCase());
+		}
+
 		public static string WithProperty(this Type type, string property)
 		{
 			return string.Format("{0}.{1}", type.FullName, property);

--- a/FigmaSharp/FigmaSharp.Cocoa/Extensions/FigmaExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Extensions/FigmaExtensions.cs
@@ -53,7 +53,7 @@ namespace FigmaSharp.Cocoa
         {
             foreach (var node in rendererService.NodesProcessed)
             {
-                if ( node.FigmaNode.name == name)
+                if ( node.Node.name == name)
                 {
                     return (NSView)node.View.NativeObject;
                 }

--- a/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
@@ -52,34 +52,39 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
 
 				if (currentNode.Node is IAbsoluteBoundingBox absoluteBounding)
 				{
-					var constrainedNode = currentNode.Node as IConstraints;
-
 					var name = currentNode.Name;
-					
-					//width
-					var widthConstraintName = $"{name}WidthConstraint";
 
-					var widthMaxStringValue = Math.Max(absoluteBounding.absoluteBoundingBox.Width, 1).ToDesignerString ();
-					var widthConstraintStringValue = CodeGenerationHelpers.GetWidthConstraintEqualToConstant (name, widthMaxStringValue);
-					builder.AppendLine($"var {widthConstraintName} = {widthConstraintStringValue};");
+					if (rendererService.HasWidthConstraint(currentNode.Node, converter))
+					{
+						//width
+						var widthConstraintName = $"{name}WidthConstraint";
 
-					if (rendererService.IsFlexibleHorizontal (currentNode, converter))
-						builder.WritePropertyEquality(widthConstraintName, nameof(AppKit.NSLayoutConstraint.Priority), $"({typeof(int).FullName}){typeof(NSLayoutPriority)}.{nameof(NSLayoutPriority.DefaultLow)}");
+						var widthMaxStringValue = Math.Max(absoluteBounding.absoluteBoundingBox.Width, 1).ToDesignerString();
+						var widthConstraintStringValue = CodeGenerationHelpers.GetWidthConstraintEqualToConstant(name, widthMaxStringValue);
+						builder.AppendLine($"var {widthConstraintName} = {widthConstraintStringValue};");
 
-					builder.WritePropertyEquality(widthConstraintName, nameof(AppKit.NSLayoutConstraint.Active), true);
+						if (rendererService.IsFlexibleHorizontal(currentNode, converter))
+							builder.WritePropertyEquality(widthConstraintName, nameof(AppKit.NSLayoutConstraint.Priority), $"({typeof(int).FullName}){typeof(NSLayoutPriority)}.{nameof(NSLayoutPriority.DefaultLow)}");
 
-					//height
-					var heightConstraintName = $"{name}HeightConstraint";
+						builder.WritePropertyEquality(widthConstraintName, nameof(AppKit.NSLayoutConstraint.Active), true);
 
-					var heightStringValue = Math.Max(absoluteBounding.absoluteBoundingBox.Height, 1).ToDesignerString();
-					var heightConstraintStringValue = CodeGenerationHelpers.GetHeightConstraintEqualToConstant(name, heightStringValue);
+					}
 
-					builder.AppendLine($"var {heightConstraintName} = {heightConstraintStringValue};");
+					if (rendererService.HasHeightConstraint(currentNode.Node, converter))
+					{
+						//height
+						var heightConstraintName = $"{name}HeightConstraint";
 
-					if (rendererService.IsFlexibleVertical(currentNode, converter))
-						builder.WritePropertyEquality(heightConstraintName, nameof(AppKit.NSLayoutConstraint.Priority), $"({typeof (int).FullName}){typeof(NSLayoutPriority)}.{nameof(NSLayoutPriority.DefaultLow)}");
+						var heightStringValue = Math.Max(absoluteBounding.absoluteBoundingBox.Height, 1).ToDesignerString();
+						var heightConstraintStringValue = CodeGenerationHelpers.GetHeightConstraintEqualToConstant(name, heightStringValue);
 
-					builder.WritePropertyEquality(heightConstraintName, nameof(AppKit.NSLayoutConstraint.Active), true);
+						builder.AppendLine($"var {heightConstraintName} = {heightConstraintStringValue};");
+
+						if (rendererService.IsFlexibleVertical(currentNode, converter))
+							builder.WritePropertyEquality(heightConstraintName, nameof(AppKit.NSLayoutConstraint.Priority), $"({typeof(int).FullName}){typeof(NSLayoutPriority)}.{nameof(NSLayoutPriority.DefaultLow)}");
+
+						builder.WritePropertyEquality(heightConstraintName, nameof(AppKit.NSLayoutConstraint.Active), true);
+					}
 
 					return builder.ToString();
 				}

--- a/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
@@ -48,8 +48,10 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
 		{
 			if (propertyName == PropertyNames.Frame)
 			{
-				System.Text.StringBuilder builder = new System.Text.StringBuilder();
+				if (!rendererService.HasConstraints(currentNode.Node, converter))
+					return string.Empty;
 
+				System.Text.StringBuilder builder = new System.Text.StringBuilder();
 				if (currentNode.Node is IAbsoluteBoundingBox absoluteBounding)
 				{
 					var name = currentNode.Name;
@@ -144,6 +146,9 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
 
 			if (propertyName == PropertyNames.Constraints)
 			{
+				if (!rendererService.HasConstraints(currentNode.Node, converter))
+					return string.Empty;
+
 				if (currentNode.Node is IConstraints constrainedNode && currentNode.Node.Parent != null)
 				{
 					var parentNodeName = parentNode == null ?

--- a/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/ViewPropertyConfigure.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/ViewPropertyConfigure.cs
@@ -56,6 +56,9 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
             }
             if (propertyName == PropertyNames.Constraints)
             {
+                if (!rendererService.HasConstraints(currentNode, converter))
+                    return;
+
                 if (currentNode is IConstraints constrainedNode && currentViewNode?.View?.NativeObject is AppKit.NSView nativeView && parentViewNode?.View?.NativeObject is AppKit.NSView parentNativeView)
                 {
                     var constraints = constrainedNode.constraints;
@@ -120,8 +123,10 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
             {
                 if (currentNode is IAbsoluteBoundingBox absoluteBounding)
                 {
-                    var nativeView = currentViewNode?.View?.NativeObject as AppKit.NSView;
+                    if (!rendererService.HasConstraints(currentNode, converter))
+                        return;
 
+                    var nativeView = currentViewNode?.View?.NativeObject as AppKit.NSView;
                     if (rendererService.HasWidthConstraint(currentNode, converter))
                     {
                         var widthConstraint = nativeView.WidthAnchor.ConstraintEqualToConstant(Math.Max(absoluteBounding.absoluteBoundingBox.Width, 1));

--- a/FigmaSharp/FigmaSharp/Converters/NodeConverter.cs
+++ b/FigmaSharp/FigmaSharp/Converters/NodeConverter.cs
@@ -106,6 +106,16 @@ namespace FigmaSharp.Converters
 			return null;
         }
 
+        internal virtual bool HasWidthConstraint ()
+        {
+            return true;
+        }
+
+        internal virtual bool HasHeightConstraint()
+        {
+            return true;
+        }
+
         internal virtual bool IsFlexibleHorizontal(FigmaNode node)
         {
             if (node is IConstraints constrainedNode)

--- a/FigmaSharp/FigmaSharp/Extensions/NodeExtensions.cs
+++ b/FigmaSharp/FigmaSharp/Extensions/NodeExtensions.cs
@@ -35,6 +35,54 @@ namespace FigmaSharp
 {
     public static class NodeExtensions
     {
+        public static bool TryGetAttributeValue(this FigmaNode node, string parameter, out string value)
+        {
+            //we want remove special chars
+            parameter = FigmaSharp.ServiceExtensions.FilterName(parameter);
+
+            value = node.name;
+            try
+            {
+                var index = value.IndexOf(parameter);
+                if (index > -1 && index < value.Length)
+                {
+                    value = value.Substring(index + parameter.Length);
+                    index = value.IndexOf("\"");
+                    if (index > -1 && index < value.Length)
+                    {
+                        value = value.Substring(index + 1);
+                        index = value.IndexOf("\"");
+                        if (index > -1 && index < value.Length)
+                        {
+                            value = value.Substring(0, index);
+                            return true;
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+            value = null;
+            return false;
+        }
+
+        public static bool TryGetChildPropertyValue(this FigmaNode node, string property, out string value)
+        {
+            if (node is IFigmaNodeContainer container && container.children != null)
+            {
+                foreach (var item in container.children)
+                {
+                    if (TryGetAttributeValue(item, property, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+            value = null;
+            return false;
+        }
+
         public static bool IsStackView (this FigmaNode node)
         {
             if (node is FigmaFrame frame)

--- a/FigmaSharp/FigmaSharp/Extensions/ServiceExtensions.cs
+++ b/FigmaSharp/FigmaSharp/Extensions/ServiceExtensions.cs
@@ -181,7 +181,7 @@ namespace FigmaSharp
 		{
 			foreach (var node in rendererService.NodesProcessed)
 			{
-				if (node.View.NativeObject is T && node.FigmaNode.name == name)
+				if (node.View.NativeObject is T && node.Node.name == name)
 				{
 					return (T)node.View.NativeObject;
 				}
@@ -193,7 +193,7 @@ namespace FigmaSharp
 		{
 			foreach (var node in rendererService.NodesProcessed)
 			{
-				if (node.View.NativeObject is T && node.FigmaNode.name == name)
+				if (node.View.NativeObject is T && node.Node.name == name)
 				{
 					yield return (T)node.View.NativeObject;
 				}
@@ -204,7 +204,7 @@ namespace FigmaSharp
 		{
 			foreach (var node in rendererService.NodesProcessed)
 			{
-				if (node.View.NativeObject is T && node.FigmaNode.name.StartsWith(name, stringComparison))
+				if (node.View.NativeObject is T && node.Node.name.StartsWith(name, stringComparison))
 				{
 					yield return (T)node.View.NativeObject;
 				}

--- a/FigmaSharp/FigmaSharp/Extensions/StringExtensions.cs
+++ b/FigmaSharp/FigmaSharp/Extensions/StringExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Authors:
+//   jmedrano <josmed@microsoft.com>
+//
+// Copyright (C) 2020 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+using System;
+namespace FigmaSharp
+{
+    public static class StringExtensions
+    {
+        public static string ToCamelCase(this string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return string.Empty;
+            if (s.Length == 1)
+                return char.ToUpper(s[0]).ToString();
+            return char.ToUpper(s[0]) + s.Substring(1);
+        }
+    }
+}

--- a/FigmaSharp/FigmaSharp/PropertyConfigure/ViewPropertyConfigureBase.cs
+++ b/FigmaSharp/FigmaSharp/PropertyConfigure/ViewPropertyConfigureBase.cs
@@ -26,14 +26,13 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-using FigmaSharp.Models;
+using FigmaSharp.Converters;
 using FigmaSharp.Services;
-using FigmaSharp.Views;
 
 namespace FigmaSharp.PropertyConfigure
 {
     public abstract class ViewPropertyConfigureBase
     {
-        public abstract void Configure(string propertyName, IView view, FigmaNode currentNode, IView parent, FigmaNode parentNode, ViewRenderService rendererService);
+        public abstract void Configure(string propertyName, ViewNode currentNode, ViewNode parentNode, NodeConverter converter, ViewRenderService rendererService);
     }
 }

--- a/FigmaSharp/FigmaSharp/Services/CodeRendererService.cs
+++ b/FigmaSharp/FigmaSharp/Services/CodeRendererService.cs
@@ -160,22 +160,12 @@ namespace FigmaSharp.Services
 			}
 		}
 
-		public NodeConverter GetNodeConverter (CodeNode node)
+        public NodeConverter GetNodeConverter (CodeNode node)
         {
 			var converter = GetConverter(node, CustomConverters);
 			if (converter == null)
 				converter = GetConverter(node, DefaultConverters);
 			return converter;
-		}
-
-        internal virtual bool IsFlexibleVertical(CodeNode nodeNode, NodeConverter converter)
-        {
-			return converter.IsFlexibleVertical(nodeNode.Node);
-		}
-
-        internal virtual bool IsFlexibleHorizontal(CodeNode nodeNode, NodeConverter converter)
-        {
-			return converter.IsFlexibleHorizontal (nodeNode.Node);
 		}
 
         protected virtual bool RendersConstraints(CodeNode node, CodeNode parent, CodeRenderService figmaCodeRendererService)

--- a/FigmaSharp/FigmaSharp/Services/Nodes/CodeNode.cs
+++ b/FigmaSharp/FigmaSharp/Services/Nodes/CodeNode.cs
@@ -3,19 +3,16 @@ using FigmaSharp.Models;
 
 namespace FigmaSharp.Services
 {
-	public class CodeNode
+    public class CodeNode : ContainerNode
 	{
-		public CodeNode (FigmaNode node, string name = null, bool isClass = false, CodeNode parent = null)
+		public CodeNode (FigmaNode node, string name = null, bool isClass = false, CodeNode parent = null) : base (node)
 		{
-			Node = node;
 			Name = name;
 			IsClass = isClass;
 			Parent = parent;
 		}
 
 		public bool HasName => !string.IsNullOrEmpty (Name);
-
-		public FigmaNode Node { get; private set; }
 
 		public CodeNode Parent { get; private set; }
 

--- a/FigmaSharp/FigmaSharp/Services/Nodes/ContainerNode.cs
+++ b/FigmaSharp/FigmaSharp/Services/Nodes/ContainerNode.cs
@@ -1,0 +1,15 @@
+﻿
+using FigmaSharp.Models;
+
+namespace FigmaSharp.Services
+{
+    public class ContainerNode
+    {
+        public FigmaNode Node { get; private set; }
+
+        public ContainerNode(FigmaNode figmaNode)
+        {
+            Node = figmaNode;
+        }
+    }
+}

--- a/FigmaSharp/FigmaSharp/Services/Nodes/ViewNode.cs
+++ b/FigmaSharp/FigmaSharp/Services/Nodes/ViewNode.cs
@@ -26,24 +26,23 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+using FigmaSharp.Models;
 using FigmaSharp.Views;
 
-namespace FigmaSharp.Models
+namespace FigmaSharp.Services
 {
-    public class ViewNode
+    public class ViewNode : ContainerNode
     {
-        public ViewNode (FigmaNode figmaNode, IView view, ViewNode parentView = null)
+        public ViewNode (FigmaNode figmaNode, IView view, ViewNode parentView = null) : base (figmaNode)
         {
-            FigmaNode = figmaNode;
             View = view;
             ParentView = parentView;
         }
 
-        public FigmaNode FigmaNode { get; set; }
         public IView View { get; set; }
         public ViewNode ParentView { get; set; }
 
         public override string ToString() =>
-            FigmaNode?.ToString() ?? base.ToString();
+            base.Node?.ToString() ?? base.ToString();
     }
 }

--- a/FigmaSharp/FigmaSharp/Services/Providers/AssemblyResourceNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/AssemblyResourceNodeProvider.cs
@@ -57,7 +57,7 @@ namespace FigmaSharp.Services
             {
                 foreach (var vector in imageFigmaNodes)
                 {
-                    var recoveredKey = ResourceHelper.FromLocalResourceNameToUrlResourceName(vector.FigmaNode.id);
+                    var recoveredKey = ResourceHelper.FromLocalResourceNameToUrlResourceName(vector.Node.id);
                     var image = AppContext.Current.GetImageFromManifest(Assembly, recoveredKey);
                     if (image != null && vector.View is IImageView imageView)
                     {

--- a/FigmaSharp/FigmaSharp/Services/Providers/FileNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/FileNodeProvider.cs
@@ -61,7 +61,7 @@ namespace FigmaSharp.Services
                 {
                     try
                     {
-                        var recoveredKey = ResourceHelper.FromLocalResourceNameToUrlResourceName(vector.FigmaNode.id);
+                        var recoveredKey = ResourceHelper.FromLocalResourceNameToUrlResourceName(vector.Node.id);
                         string filePath = Path.Combine(ResourcesDirectory, string.Concat(recoveredKey, ImageFormat));
 
                         if (!System.IO.File.Exists(filePath))

--- a/FigmaSharp/FigmaSharp/Services/Providers/RemoteNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/RemoteNodeProvider.cs
@@ -71,7 +71,7 @@ namespace FigmaSharp.Services
                 {
                     var vectors = imageFigmaNodes.Skip(i * CallNumber).Take(CallNumber);
                     Console.WriteLine("[{0}/{1}] Processing Images ... {2} ", i, numberLoop, vectors.Count());
-                    var ids = vectors.Select(s => CreateEmptyImageNodeRequest(s.FigmaNode))
+                    var ids = vectors.Select(s => CreateEmptyImageNodeRequest(s.Node))
                         .ToArray();
 
                     var figmaImageResponse = AppContext.Api.GetImages(File, ids, imageFormat);
@@ -110,8 +110,8 @@ namespace FigmaSharp.Services
 
                         foreach (var figmaNodeId in imageUrl.Item2)
                         {
-                            var vector = imageFigmaNodes.FirstOrDefault(s => s.FigmaNode.id == figmaNodeId);
-                            Console.Write("[{0}:{1}:{2}] {3}...", vector.FigmaNode.GetType(), vector.FigmaNode.id, vector.FigmaNode.name, imageUrl);
+                            var vector = imageFigmaNodes.FirstOrDefault(s => s.Node.id == figmaNodeId);
+                            Console.Write("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
 
                             if (vector != null && vector.View is ISvgView imageView)
                             {
@@ -132,8 +132,8 @@ namespace FigmaSharp.Services
                         var Image = AppContext.Current.GetImage(imageUrl.Item1);
                         foreach (var figmaNodeId in imageUrl.Item2)
                         {
-                            var vector = imageFigmaNodes.FirstOrDefault(s => s.FigmaNode.id == figmaNodeId);
-                            Console.WriteLine("[{0}:{1}:{2}] {3}...", vector.FigmaNode.GetType(), vector.FigmaNode.id, vector.FigmaNode.name, imageUrl);
+                            var vector = imageFigmaNodes.FirstOrDefault(s => s.Node.id == figmaNodeId);
+                            Console.WriteLine("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
 
                             if (vector != null)
                             {
@@ -149,7 +149,7 @@ namespace FigmaSharp.Services
                                     }
                                     else
                                     {
-                                        Console.WriteLine("[{0}:{1}:{2}] Error cannot assign the image to the current view {3}", vector.FigmaNode.GetType(), vector.FigmaNode.id, vector.FigmaNode.name, vector.View.GetType().FullName);
+                                        Console.WriteLine("[{0}:{1}:{2}] Error cannot assign the image to the current view {3}", vector.Node.GetType(), vector.Node.id, vector.Node.name, vector.View.GetType().FullName);
                                     }
                                 });
                             }

--- a/FigmaSharp/FigmaSharp/Services/RenderService.cs
+++ b/FigmaSharp/FigmaSharp/Services/RenderService.cs
@@ -89,6 +89,27 @@ namespace FigmaSharp.Services
             return null;
         }
 
+
+        internal virtual bool HasWidthConstraint(FigmaNode currentNode, NodeConverter converter)
+        {
+            return converter.HasWidthConstraint();
+        }
+
+        internal virtual bool HasHeightConstraint(FigmaNode currentNode, NodeConverter converter)
+        {
+            return converter.HasHeightConstraint();
+        }
+
+        internal virtual bool IsFlexibleVertical(ContainerNode currentNode, NodeConverter converter)
+        {
+            return converter.IsFlexibleVertical(currentNode.Node);
+        }
+
+        internal virtual bool IsFlexibleHorizontal(ContainerNode currentNode, NodeConverter converter)
+        {
+            return converter.IsFlexibleHorizontal(currentNode.Node);
+        }
+
         internal string GetTranslatedText(string text)
         {
             if (baseOptions.TranslateLabels && TranslationService != null)
@@ -96,6 +117,14 @@ namespace FigmaSharp.Services
                 return TranslationService.GetTranslatedStringText(text);
             }
             return text;
+        }
+
+        public NodeConverter GetConverter(FigmaNode node)
+        {
+            var converter = GetProcessedConverter(node, CustomConverters);
+            if (converter == null)
+                converter = GetProcessedConverter(node, DefaultConverters);
+            return converter;
         }
 
         protected NodeConverter GetProcessedConverter(FigmaNode currentNode, IEnumerable<NodeConverter> customViewConverters)

--- a/FigmaSharp/FigmaSharp/Services/RenderService.cs
+++ b/FigmaSharp/FigmaSharp/Services/RenderService.cs
@@ -89,6 +89,18 @@ namespace FigmaSharp.Services
             return null;
         }
 
+        const string HasConstraintsParameter = "hasConstraints";
+        internal virtual bool HasConstraints(FigmaNode currentNode, NodeConverter converter)
+        {
+            if (currentNode.TryGetAttributeValue(HasConstraintsParameter, out var value))
+            {
+                if (value == "true")
+                    return true;
+                if (value == "false")
+                    return false;
+            }
+            return true;
+        }
 
         internal virtual bool HasWidthConstraint(FigmaNode currentNode, NodeConverter converter)
         {

--- a/tools/FigmaSharp.Designer/FigmaDesignerSession.cs
+++ b/tools/FigmaSharp.Designer/FigmaDesignerSession.cs
@@ -51,7 +51,7 @@ namespace FigmaSharp.Designer
 
         public List<ViewNode> ProcessedNodes => rendererService.NodesProcessed;
 
-        public ViewNode[] MainViews => rendererService.NodesProcessed.Where (s => s.ParentView != null && s.ParentView.FigmaNode is FigmaCanvas).ToArray ();
+        public ViewNode[] MainViews => rendererService.NodesProcessed.Where (s => s.ParentView != null && s.ParentView.Node is FigmaCanvas).ToArray ();
 
         public FigmaDesignerSession(INodeProvider figmaFileProvider, ViewRenderService figmaViewRendererService, StoryboardLayoutManager figmaViewRendererDistributionService)
         {
@@ -111,14 +111,14 @@ namespace FigmaSharp.Designer
 
         public IView GetViewWrapper(FigmaNode e)
         {
-            var processed = ProcessedNodes.FirstOrDefault(s => s.FigmaNode == e);
+            var processed = ProcessedNodes.FirstOrDefault(s => s.Node == e);
             return processed?.View;
         }
 
         public FigmaNode GetModel(IView e)
         {
             var processed = ProcessedNodes.FirstOrDefault(s => s.View != null && s.View.NativeObject == e.NativeObject);
-            return processed?.FigmaNode;
+            return processed?.Node;
         }
 
         public void DeleteView(FigmaNode e)

--- a/tools/MonoDevelop.Figma/MonoDevelop.Figma.csproj
+++ b/tools/MonoDevelop.Figma/MonoDevelop.Figma.csproj
@@ -141,19 +141,19 @@
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\PackageUpdateWindow.cs" />
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\PackageUpdateWindow.designer.cs">
           <FigmaPackageId>ea4pU30ht61lUJXcr0TFIF</FigmaPackageId>
-          <FigmaNodeId>38:682</FigmaNodeId>
+          <FigmaNodeCustomName>PackageUpdateWindow</FigmaNodeCustomName>
           <DependentUpon>PackageUpdateWindow.cs</DependentUpon>
         </Compile>
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\FigmaPackageWindow.cs" />
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\FigmaPackageWindow.designer.cs">
           <FigmaPackageId>ea4pU30ht61lUJXcr0TFIF</FigmaPackageId>
-          <FigmaNodeId>38:693</FigmaNodeId>
+          <FigmaNodeCustomName>FigmaPackageWindow</FigmaNodeCustomName>
           <DependentUpon>FigmaPackageWindow.cs</DependentUpon>
         </Compile>
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\GenerateViewsWindow.cs" />
         <Compile Include=".figma\ea4pU30ht61lUJXcr0TFIF\Views\GenerateViewsWindow.designer.cs">
           <FigmaPackageId>ea4pU30ht61lUJXcr0TFIF</FigmaPackageId>
-          <FigmaNodeId>38:714</FigmaNodeId>
+          <FigmaNodeCustomName>GenerateViewsWindow</FigmaNodeCustomName>
           <DependentUpon>GenerateViewsWindow.cs</DependentUpon>
         </Compile>
       </ItemGroup>


### PR DESCRIPTION
This PR adds some extra functionality to include in views overriding the default behaviour using the Figma Designer

Sometimes, depending the view we need to be flexible and allow any view to grow, sometimes because the translation needs a bigger container or because resize proportions purposes. Thats because we created some new APIs to allow handle this special cases, using some attributes in the node.

StackView:
Adds attributes:
- distribution:"equalCentering|equalSpacing|fill|fillEqually|fillProportionally|gravityAreas" = adds different behaviours distributing elements based in cocoa api https://developer.apple.com/documentation/appkit/nsstackview/distribution

Nodes:
Adds attributes:
- isFlexibleHorizontal:"true|false" = allows grow the view horizontally 
- isFlexibleVertical:"true|false" = allows grow the view vertically
- hasWidthConstraint:"true|false" = adds fixed constraints for width (it can be combined with isFlexibleHorizontal)
- hasHeightConstraint:"true|false" = adds fixed constraints for height (it can be combined with isFlexibleVertical)
- hasConstraints: "true|false" = don't add constraints in this view (all the other options are not taking into account


this PR also fixes the Standalone App to use this magic.


![image](https://user-images.githubusercontent.com/1587480/88305866-4d643000-cd0a-11ea-878d-33beb2466644.png)
